### PR TITLE
MSWebdrivers now uses Edge version to download the correct binary version.

### DIFF
--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -4,51 +4,42 @@ module Webdrivers
 
       def current
         Webdrivers.logger.debug "Checking current version"
-        version = %x(ver)
-        Webdrivers.logger.debug "Current version of Windows Build is #{version}"
-        version[/\d+\.\d+\.\d+/][/[^\.]\d+$/]
-      end
 
-      def latest
-        # unknown; have to always download
+        # current() from other webdrivers returns the version from the webdriver EXE.
+        # Unfortunately, MicrosoftWebDriver.exe does not have an option to get the version.
+        # To work around it we query the currently installed version of Microsoft Edge instead
+        # and compare it to the list of available downloads.
+        version = `powershell (Get-AppxPackage -Name Microsoft.MicrosoftEdge).Version`
+        raise "Failed to check Microsoft Edge version." if version.empty? # Package name changed?
+        Webdrivers.logger.debug "Current version of Microsoft Edge is #{version.chomp!}"
+
+        build = version.split('.')[1] # "41.16299.248.0" => "16299"
+        Webdrivers.logger.debug "Expecting MicrosoftWebDriver.exe version #{build}"
+        build.to_i
       end
 
       private
 
       def normalize(string)
-        string.match(/(\d+)\.(\d+\.\d+)/).to_a.map {|v| v.tr('.', '')}[1..-1].join('.').to_f
+        string.match(/(\d+)\.(\d+\.\d+)/).to_a.map { |v| v.tr('.', '') }[1 .. -1].join('.').to_f
       end
 
       def file_name
         "MicrosoftWebDriver.exe"
       end
 
-      def download_url(_version = nil)
+      def downloads
         raise StandardError, "Can not reach site" unless site_available?
-
-        case current.to_i
-        when 10240
-          Webdrivers.logger.debug "Attempting to Download Build for 10240"
-          "https://download.microsoft.com/download/8/D/0/8D0D08CF-790D-4586-B726-C6469A9ED49C/MicrosoftWebDriver.msi"
-        when 10586
-          Webdrivers.logger.debug "Attempting to Download Build for 10586"
-          "https://download.microsoft.com/download/C/0/7/C07EBF21-5305-4EC8-83B1-A6FCC8F93F45/MicrosoftWebDriver.msi"
-        when 14393
-          Webdrivers.logger.debug "Attempting to Download Build for 14393"
-          "https://download.microsoft.com/download/3/2/D/32D3E464-F2EF-490F-841B-05D53C848D15/MicrosoftWebDriver.exe"
-        when 15063
-          Webdrivers.logger.debug "Attempting to Download Build for 15063"
-          "https://download.microsoft.com/download/3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/MicrosoftWebDriver.exe"
-        else
-          Webdrivers.logger.debug "Attempting to Download Latest Insider's Version"
-          "https://download.microsoft.com/download/1/4/1/14156DA0-D40F-460A-B14D-1B264CA081A5/MicrosoftWebDriver.exe"
+        array = Nokogiri::HTML(get(base_url)).xpath("//li[@class='driver-download']/a")
+        array.each_with_object({}) do |link, hash|
+          next if link.text == 'Insiders'
+          hash[link.text.scan(/\d+/).first.to_i] = link['href']
         end
       end
 
       def base_url
-        'https://www.microsoft.com/en-us/download'
+        'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
       end
-
     end
   end
 end

--- a/spec/mswebdriver_spec.rb
+++ b/spec/mswebdriver_spec.rb
@@ -19,7 +19,7 @@ describe Webdrivers::MSWebdriver do
     before { allow(mswebdriver).to receive(:site_available?).and_return(false) }
 
     it 'raises exception downloading' do
-      expect {mswebdriver.download}.to raise_error(StandardError, "Can not reach site")
+      expect { mswebdriver.download }.to raise_error(StandardError, "Can not reach site")
     end
   end
 


### PR DESCRIPTION
Hi @titusfortner,

I have updated the `MSWebdriver` implementation.  Earlier it would raise an error asking the user to manually download the binary. With this PR it now queries the current Edge version and downloads the corresponding binary from the Microsoft developer website if an existing binary does not exist.

I have added a spec to verify edge version is retrieved and all existing specs still pass.

## Caveat

Unfortunately, because `MicrosoftWebDriver.exe` does not provide a `--version` option, there is no way to verify if an existing binary is the correct version or not. We instead use the Edge version from Windows Registry to download the corresponding binary, if one does not already exist in `.webdrivers`.

```
USAGE:
        MicrosoftWebDriver [OPTIONS]

OPTIONS:
        --host=<HostName>    Host IP to use for the WebDriver server (default: localhost)
        --port=<PortNumber>  Port to use for the WebDriver server (default: 17556)
        --package=<Package>  ApplicationUserModelId (AUMID) for the application to be launched by the WebDriver server
        --verbose            Outputs requests received and responses sent by the WebDriver server
        --silent             Outputs nothing
```

If a binary already exists, the implementation simply assumes it is the expected version and returns the `location`. If the existing binary is incompatible, the user will see the following from Selenium:

```
unable to connect to MicrosoftWebDriver localhost:17556
```

If we proceed with this, we'll have to advise the user to delete the existing binary and retry. Let me know what you think of this implementation.