### PR TITLE
MSWebdriver now fetches the binary corresponding to the currently installed Edge version instead of the latest one.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ in your Gemfile:
 
 in your project:
 
-`require 'webdrivers'
+`require 'webdrivers'`
 
 If there is a proxy between you and the Internet then you will need to configure
 the gem to use the proxy.  You can do this by calling the `configure` method.
@@ -37,6 +37,18 @@ Webdrivers.configure do |config|
   config.proxy_pass = 'password'
 end
 ````
+
+**Note when using Microsoft Edge**:
+
+After updating Microsoft Edge on Windows 10, you will need to delete the existing binary (`%USERPROFILE%/.webdrivers/MicrosoftWebDriver.exe`) to
+to be able to download the latest version through this gem.
+
+This is because `MicrosoftWebDriver.exe` is not backwards compatible and it does not have an argument to retrieve 
+the current version. We work around this limitation by querying the current Edge version from the registry and 
+fetching the corresponding binary IF a file does not already exist. If a file does exist, the gem assumes it is the 
+expected version and skips the download process.
+
+If you continue with the outdated binary, Selenium will throw an error: `unable to connect to MicrosoftWebDriver localhost:17556`.
 
 # License
 

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -9,24 +9,23 @@ module Webdrivers
         unless site_available?
           return current.nil? ? nil : binary
         end
-        released      = latest()
-        location      = binary()
-        binary_exists = File.exists?(location)
+        released = latest()
+        location = binary()
 
-        return location if released.nil? && binary_exists
+        return location if released.nil? && File.exists?(binary) # Newer not found, keep current
 
-        if released.nil?
+        if released.nil? # Can't find latest and no existing binary
           msg = "Unable to find the latest version of #{file_name}; try downloading manually from #{base_url} and place in #{install_dir}"
           raise StandardError, msg
         end
 
-        if current == released && binary_exists # Already have latest/matching one
+        if correct_binary?
           Webdrivers.logger.debug "Expected webdriver version found"
           return location
         end
 
-        remove if binary_exists # Remove outdated exe
-        download
+        remove # Remove outdated exe
+        download # Fetch latest
       end
 
       def latest
@@ -178,6 +177,12 @@ module Webdrivers
       def install_dir
         File.expand_path(File.join(ENV['HOME'], ".webdrivers")).tap { |dir| FileUtils.mkdir_p dir }
       end
+
+      # Already have latest version downloaded?
+      def correct_binary?
+        latest == current && File.exists?(binary)
+      end
+
     end
   end
 end

--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -1,5 +1,6 @@
 module Webdrivers
   class MSWebdriver < Common
+
     class << self
 
       def current
@@ -16,6 +17,13 @@ module Webdrivers
         build = version.split('.')[1] # "41.16299.248.0" => "16299"
         Webdrivers.logger.debug "Expecting MicrosoftWebDriver.exe version #{build}"
         build.to_i
+      end
+
+      # Webdriver binaries for Microsoft Edge are not backwards compatible.
+      # For this reason, instead of downloading the latest binary we download the correct one for the
+      # currently installed browser version.
+      def download(version = current)
+        super
       end
 
       private
@@ -40,6 +48,13 @@ module Webdrivers
       def base_url
         'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
       end
+
+      # Assume we have the latest if file exists since MicrosoftWebdriver.exe does not have an
+      # argument to check the current version.
+      def correct_binary?
+        File.exist?(binary)
+      end
+
     end
   end
 end

--- a/spec/geckodriver_spec.rb
+++ b/spec/geckodriver_spec.rb
@@ -7,7 +7,7 @@ describe Webdrivers::Geckodriver do
   it 'raises exception if unable to get latest geckodriver and no geckodriver present' do
     geckodriver.remove
     allow(geckodriver).to receive(:latest).and_return(nil)
-    msg = /^Unable to find the latest version of geckodriver; try downloading manually from (.*)?and place in (.*)?\.webdrivers$/
+    msg = /^Unable to find the latest version of geckodriver(.exe)?; try downloading manually from (.*)?and place in (.*)?\.webdrivers$/
     expect { geckodriver.update }.to raise_exception StandardError, msg
   end
 

--- a/spec/mswebdriver_spec.rb
+++ b/spec/mswebdriver_spec.rb
@@ -6,7 +6,7 @@ describe Webdrivers::MSWebdriver do
 
   it 'downloads mswebdriver' do
     mswebdriver.remove
-    allow(mswebdriver).to receive(:current).and_return(0)
+    allow(mswebdriver).to receive(:current)
     expect(File.exist?(mswebdriver.download)).to be true
   end
 


### PR DESCRIPTION
This PR fixes issue #14 and updates the README.

Since `MicrosoftWebDriver.exe` is not backwards compatible, we cannot always update to the latest version. This PR allows `webdrivers` gem to download the correct version for the currently installed version of Edge.

It also fixes the bug where the gem would re-download the binary when `current != released`. It now assumes that an existing binary is the correct version and skips the download process.