### PR TITLE
Read LATEST_RELEASE file for chromedriver

### DIFF
--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -13,11 +13,7 @@ module Webdrivers
       end
 
       def latest
-        Gem::Version.new('2.42')
-      end
-
-      def download(version = 2.42)
-        super
+        Gem::Version.new(get(URI.join(base_url, "LATEST_RELEASE")))
       end
 
       private


### PR DESCRIPTION
The following change reads the latest stable version of chromedriver from the `LATEST_RELEASE` file instead of scanning the downloads or hardcoding the version.

According to
https://groups.google.com/forum/#!msg/chromedriver-users/NVC4tnXS58k/LNw6rBlBCAAJ
the chromdriver team is running experiments on a future release model.
> To avoid picking up the experiment code, it is recommended that tools
should rely on
https://chromedriver.storage.googleapis.com/LATEST_RELEASE to pick up
the latest version of ChromeDriver, instead of scanning the directories.

Fixes #19 