### PR TITLE
fixed error with invalid regex

### DIFF
--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -9,7 +9,7 @@ module Webdrivers
         return nil unless downloaded?
         string = %x(#{binary} --version)
         Webdrivers.logger.debug "Current version of #{binary} is #{string}"
-        normalize string.match(/ChromeDriver (\d\.\d+)/)[1]
+        normalize string.match(/ChromeDriver (\d+\.\d+)/)[1]
       end
 
       def latest


### PR DESCRIPTION
The invalid regex 
```
string.match(/ChromeDriver (\d\.\d+)/)[1]
```
was causing the following error 
```
NoMethodError - undefined method `[]' for nil:NilClass
```
at the following line of code
```
gems/webdrivers-3.2.2/lib/webdrivers/chromedriver.rb:12:in `current'
```

The actual reproduction in memory
```
string = "ChromeDriver 70.0.3538.16 (16ed95b41bb05e565b11fb66ac33c660b721f778)\n"
```

The modified regex below will support for when versions of the chrome driver has more than 1 digit in its first section.
```
string.match(/ChromeDriver (\d+\.\d+)/)[1]
```