### PR TITLE
Use HTTPS to download Chromedriver and IEDriver

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ If you continue with the outdated binary, Selenium will throw an error: `unable 
 
 # License
 
-The gem is available as open source under the terms of the [MIT License](http://opensource.org/licenses/MIT), 
+The gem is available as open source under the terms of the [MIT License](https://opensource.org/licenses/MIT),
 see LICENSE.txt for full details and copyright.
 
 

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -23,7 +23,7 @@ module Webdrivers
       end
 
       def base_url
-        'http://chromedriver.storage.googleapis.com'
+        'https://chromedriver.storage.googleapis.com'
       end
 
       def downloads

--- a/lib/webdrivers/iedriver.rb
+++ b/lib/webdrivers/iedriver.rb
@@ -20,7 +20,7 @@ module Webdrivers
       end
 
       def base_url
-        'http://selenium-release.storage.googleapis.com/'
+        'https://selenium-release.storage.googleapis.com/'
       end
 
       def downloads

--- a/spec/iedriver_spec.rb
+++ b/spec/iedriver_spec.rb
@@ -6,7 +6,7 @@ describe Webdrivers::IEdriver do
 
   it 'finds latest version' do
     old_version = Gem::Version.new("3.12.0")
-    future_version = Gem::Version.new("3.60.0")
+    future_version = Gem::Version.new("3.160.0")
     latest_version = iedriver.latest
 
     expect(latest_version).to be > old_version


### PR DESCRIPTION
Current webdrivers uses insecure transport communication to download code and runs no additional authenticity checks, allowing attackers with network access to execute arbitrary code (via an MITM attack, when the victim subsequently executes a webdriver).