### PR TITLE
Chromedriver#latest_version now returns latest binary version corresponding to the installed Chrome version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,11 @@
 sudo: required
-dist: trusty
+os:
+  - linux
+  - osx
 language: ruby
 cache: bundler
 rvm:
   - 2.4.1
   - jruby-9.2.0.0
+addons:
+  chrome: stable

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -14,7 +14,11 @@ module Webdrivers
 
       def latest_version
         raise StandardError, "Can not reach site" unless site_available?
-        Gem::Version.new(get(URI.join(base_url, "LATEST_RELEASE")))
+
+        # Latest webdriver release for installed Chrome version
+        release_file     = "LATEST_RELEASE_#{release_version}"
+        latest_available = get(URI.join(base_url, release_file))
+        Gem::Version.new(latest_available)
       end
 
       private
@@ -31,11 +35,11 @@ module Webdrivers
         Webdrivers.logger.debug "Versions previously located on downloads site: #{@downloads.keys}" if @downloads
 
         @downloads ||= begin
-          doc = Nokogiri::XML.parse(get(base_url))
+          doc   = Nokogiri::XML.parse(get(base_url))
           items = doc.css("Contents Key").collect(&:text)
-          items.select! {|item| item.include?(platform)}
+          items.select! { |item| item.include?(platform) }
           ds = items.each_with_object({}) do |item, hash|
-            key = normalize item[/^[^\/]+/]
+            key       = normalize item[/^[^\/]+/]
             hash[key] = "#{base_url}/#{item}"
           end
           Webdrivers.logger.debug "Versions now located on downloads site: #{ds.keys}"
@@ -43,6 +47,45 @@ module Webdrivers
         end
       end
 
+      # Returns release version from the currently installed Chrome version
+      #
+      # @example
+      #   73.0.3683.75 -> 73.0.3683
+      def release_version
+        chrome_version[/\d+\.\d+\.\d+/]
+      end
+
+      # Returns currently installed Chrome version
+      def chrome_version
+        ver = case platform
+                when 'win'
+                  chrome_on_windows
+                when /linux/
+                  chrome_on_linux
+                when 'mac'
+                  chrome_on_mac
+                else
+                  raise NotImplementedError, 'Your OS is not supported by webdrivers gem.'
+              end.chomp
+
+        # Google Chrome 73.0.3683.75 -> 73.0.3683.75
+        ver[/(\d|\.)+/]
+      end
+
+      def chrome_on_windows
+        reg = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
+        ps  = "(Get-Item (Get-ItemProperty '#{reg}').'(Default)').VersionInfo.ProductVersion"
+        `powershell #{ps}`
+      end
+
+      def chrome_on_linux
+        `google-chrome --version`
+      end
+
+      def chrome_on_mac
+        loc = Shellwords.escape '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        `#{loc} --version`
+      end
     end
   end
 end

--- a/spec/chromedriver_spec.rb
+++ b/spec/chromedriver_spec.rb
@@ -13,18 +13,20 @@ describe Webdrivers::Chromedriver do
   end
 
   it 'finds latest version' do
-    old_version = Gem::Version.new("2.30")
-    future_version = Gem::Version.new("2.90")
+    old_version = Gem::Version.new('2.30')
+    future_version = Gem::Version.new('80.00')
     latest_version = chromedriver.latest_version
 
     expect(latest_version).to be > old_version
     expect(latest_version).to be < future_version
   end
 
-  it 'downloads latest version by default' do
+  it 'downloads latest release for current version of Chrome by default' do
     chromedriver.remove
     chromedriver.download
-    expect(chromedriver.current_version).to eq chromedriver.latest_version
+    cur_ver    = chromedriver.current_version.version
+    latest_ver = chromedriver.latest_version.version[0..3] # "72.0.3626.69" - > "72.0"
+    expect(cur_ver).to eq latest_ver
   end
 
   it 'downloads specified version by Float' do
@@ -36,9 +38,9 @@ describe Webdrivers::Chromedriver do
 
   it 'downloads specified version by String' do
     chromedriver.remove
-    chromedriver.version = '2.29'
+    chromedriver.version = '74.0.3729.6'
     chromedriver.download
-    expect(chromedriver.current_version.version).to eq '2.29'
+    expect(chromedriver.current_version.version).to eq '74.0'
   end
 
   it 'removes chromedriver' do


### PR DESCRIPTION
#31 - Google now matches the `chromedriver` version to Chrome browser version ([source](http://chromedriver.chromium.org/downloads/version-selection)). This PR updates `Chromedriver#latest_version` to download the latest binary corresponding to the installed Chrome (major) version.

Without this change, the gem fetches `chromedriver` version 2.46 as the latest one regardless of your Chrome version.

**Example**

If you have Chrome 72.0.3626.121 installed, the gem will now fetch the latest binary release for version 72.0, which is 72.0.3626.69.

**Specs**

Windows - Pass (local @ Windows 10)
Linux - Pass (Travis)
Mac - Pass (Travis)

Updated `travis.yml` to install Chrome, and to run specs on Linux and Mac..