### PR TITLE
Chromedriver now checks Selenium::WebDriver::Chrome#path.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,3 +9,6 @@ rvm:
   - jruby-9.2.0.0
 addons:
   chrome: stable
+
+before_script:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install chromium-browser libgconf-2-4 ; fi

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -5,19 +5,26 @@ module Webdrivers
     class << self
 
       def current_version
-        Webdrivers.logger.debug "Checking current version"
+        Webdrivers.logger.debug 'Checking current version'
         return nil unless downloaded?
-        string = %x(#{binary} --version)
-        Webdrivers.logger.debug "Current version of #{binary} is #{string}"
-        normalize string.match(/ChromeDriver (\d+\.\d+)/)[1]
+
+        ver = `#{binary} --version`
+        Webdrivers.logger.debug "Current #{binary} version: #{ver}"
+
+        # Matches 2.46, 2.46.628411 and 73.0.3683.75
+        normalize ver[/\d+\.\d+(\.\d+)?(\.\d+)?/]
       end
 
       def latest_version
-        raise StandardError, "Can not reach site" unless site_available?
+        raise StandardError, 'Can not reach site' unless site_available?
+
+        # Versions before 70 do not have a LATEST_RELEASE file
+        return Gem::Version.new('2.46') if release_version < '70.0.3538'
 
         # Latest webdriver release for installed Chrome version
         release_file     = "LATEST_RELEASE_#{release_version}"
         latest_available = get(URI.join(base_url, release_file))
+        Webdrivers.logger.debug "Latest version available: #{latest_available}"
         Gem::Version.new(latest_available)
       end
 
@@ -68,23 +75,58 @@ module Webdrivers
                   raise NotImplementedError, 'Your OS is not supported by webdrivers gem.'
               end.chomp
 
+        if ver.nil? || ver.empty?
+          raise StandardError, 'Failed to find Chrome binary or its version.'
+        end
+
         # Google Chrome 73.0.3683.75 -> 73.0.3683.75
         ver[/(\d|\.)+/]
       end
 
       def chrome_on_windows
-        reg = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
-        ps  = "(Get-Item (Get-ItemProperty '#{reg}').'(Default)').VersionInfo.ProductVersion"
-        `powershell #{ps}`
+        if browser_binary
+          Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
+          return `powershell (Get-ItemProperty '#{browser_binary}').VersionInfo.ProductVersion`
+        end
+
+        # Default to Google Chrome
+        reg        = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
+        executable = `powershell (Get-ItemProperty '#{reg}' -Name '(default)').'(default)'`.strip
+        Webdrivers.logger.debug "Browser executable: '#{executable}'"
+        ps = "(Get-Item (Get-ItemProperty '#{reg}').'(default)').VersionInfo.ProductVersion"
+        `powershell #{ps}`.strip
       end
 
       def chrome_on_linux
-        `google-chrome --version`
+        if browser_binary
+          Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
+          return `#{browser_binary} --product-version`.strip
+        end
+
+        # Default to Google Chrome
+        executable = `which google-chrome`.strip
+        Webdrivers.logger.debug "Browser executable: '#{executable}'"
+        `#{executable} --product-version`.strip
       end
 
       def chrome_on_mac
-        loc = Shellwords.escape '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
-        `#{loc} --version`
+        if browser_binary
+          Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
+          return `#{browser_binary} --version`.strip
+        end
+
+        # Default to Google Chrome
+        executable = Shellwords.escape '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
+        Webdrivers.logger.debug "Browser executable: #{executable}"
+        `#{executable} --version`.strip
+      end
+
+      #
+      # Returns user defined browser executable path from Selenium::WebDrivers::Chrome#path.
+      #
+      def browser_binary
+        # For Chromium, Brave, or whatever else
+        Selenium::WebDriver::Chrome.path
       end
     end
   end

--- a/spec/chromedriver_spec.rb
+++ b/spec/chromedriver_spec.rb
@@ -25,7 +25,7 @@ describe Webdrivers::Chromedriver do
     chromedriver.remove
     chromedriver.download
     cur_ver    = chromedriver.current_version.version
-    latest_ver = chromedriver.latest_version.version[0..3] # "72.0.3626.69" - > "72.0"
+    latest_ver = chromedriver.latest_version.version
     expect(cur_ver).to eq latest_ver
   end
 
@@ -33,19 +33,35 @@ describe Webdrivers::Chromedriver do
     chromedriver.remove
     chromedriver.version = 2.29
     chromedriver.download
-    expect(chromedriver.current_version.version).to eq '2.29'
+    expect(chromedriver.current_version.version).to include '2.29'
   end
 
   it 'downloads specified version by String' do
     chromedriver.remove
-    chromedriver.version = '74.0.3729.6'
+    chromedriver.version = '73.0.3683.68'
     chromedriver.download
-    expect(chromedriver.current_version.version).to eq '74.0'
+    expect(chromedriver.current_version.version).to eq '73.0.3683.68'
   end
 
   it 'removes chromedriver' do
     chromedriver.remove
     expect(chromedriver.current_version).to be_nil
+  end
+
+  if Selenium::WebDriver::Platform.linux? && ENV['TRAVIS']
+    # Ubuntu 14.04 (trusty) is limited to v65
+    context 'when using a Chromium version < 70.0.3538' do
+      before do
+        chromedriver.remove
+        chromedriver.version = nil
+        Selenium::WebDriver::Chrome.path = `which chromium-browser`.strip
+      end
+
+      it 'downloads chromedriver 2.46' do
+        chromedriver.update
+        expect(chromedriver.current_version.version[/\d+.\d+/]).to eq('2.46')
+      end
+    end
   end
 
   context 'when offline' do


### PR DESCRIPTION
- Chromedriver now checks `Selenium::WebDriver::Chrome#path` before defaulting to Google Chrome. Addresses #38.
- Now downloads `chromedriver` v2.46 if Chrome/Chromium version is less than 70. `LATEST_FILE_*` only available for versions > 70.
- `Chromedriver#current_version` now returns full version - `73.0.3683.68` instead of `73.0`.