### PR TITLE
add support for heroku/heroku-buildpack-google-chrome

### DIFF
--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -79,7 +79,7 @@ module Webdrivers
       end
 
       def chrome_on_linux
-        `google-chrome --version`
+        `#{ENV['GOOGLE_CHROME_BIN'] || 'google-chrome'} --version`
       end
 
       def chrome_on_mac


### PR DESCRIPTION
Hi,

On heroku CI, with [heroku/heroku-buildpack-google-chrome](https://github.com/heroku/heroku-buildpack-google-chrome), `webdrivers` having some issues.

Heroku replaces the `google-chrome` command with the following script:
```bash
exec $HOME/.apt/opt/google/chrome/chrome --headless --no-sandbox --disable-gpu --remote-debugging-port=9222 $@
```

This script does not support the `--version` option. In fact, when you make a call to: 
```ruby
def chrome_on_linux
  `google-chrome --version`
end
```

Instead of getting the version, the script runs Google Chrome headlessly in forground.

I propose to add the support of this buildpack by checking the presence of the `shims` provided for this purpose by heroku. : https://github.com/heroku/heroku-buildpack-google-chrome#shims-and-command-line-flags

