### PR TITLE
Check if we already have the latest/desired version before checking for updates.

### DIFF
--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -18,7 +18,7 @@ module Webdrivers
           raise StandardError, update_failed_msg if current_version.nil?
 
           # Use existing binary
-          Webdrivers.logger.info "Update site is down. Using existing #{file_name}"
+          Webdrivers.logger.error "Can not reach update site. Using existing #{file_name} #{current_version}"
           return binary
         end
 
@@ -50,7 +50,7 @@ module Webdrivers
           cur_ver = current_version
           raise StandardError, update_failed_msg if cur_ver.nil? # Site is down and no existing binary
 
-          Webdrivers.logger.info "Can not reach update site. Using existing #{file_name} #{cur_ver}"
+          Webdrivers.logger.error "Can not reach update site. Using existing #{file_name} #{cur_ver}"
           return cur_ver
         end
 

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -96,7 +96,10 @@ describe Webdrivers::Chromedriver do
   end
 
   context 'when offline' do
-    before { allow(chromedriver).to receive(:site_available?).and_return(false) }
+    before do
+      chromedriver.remove
+      allow(chromedriver).to receive(:site_available?).and_return(false)
+    end
 
     it 'raises exception finding latest version if no existing binary' do
       expect { chromedriver.latest_version }.to raise_error(StandardError, update_failed_msg)

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Webdrivers::IEdriver do
   let(:iedriver) { described_class }
+  let(:update_failed_msg) { /^Update site is unreachable. Try downloading 'IEDriverServer(.exe)?' manually from (.*)?and place in '(.*)?\.webdrivers'$/ }
 
   it 'finds latest version' do
     old_version = Gem::Version.new('3.12.0')
@@ -23,14 +24,17 @@ describe Webdrivers::IEdriver do
   end
 
   context 'when offline' do
-    before { allow(iedriver).to receive(:site_available?).and_return(false) }
+    before do
+      allow(iedriver).to receive(:site_available?).and_return(false)
+      iedriver.remove
+    end
 
     it 'raises exception finding latest version' do
-      expect { iedriver.latest_version }.to raise_error(StandardError, 'Can not reach site')
+      expect { iedriver.latest_version }.to raise_error(StandardError, update_failed_msg)
     end
 
     it 'raises exception downloading' do
-      expect { iedriver.download }.to raise_error(StandardError, 'Can not reach site')
+      expect { iedriver.download }.to raise_error(StandardError, update_failed_msg)
     end
   end
 end

--- a/spec/webdrivers/ms_webdriver_spec.rb
+++ b/spec/webdrivers/ms_webdriver_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 describe Webdrivers::MSWebdriver do
   let(:mswebdriver) { described_class }
+  let(:update_failed_msg) { /^Update site is unreachable. Try downloading 'MicrosoftWebDriver(.exe)?' manually from (.*)?and place in '(.*)?\.webdrivers'$/ }
 
   it 'downloads mswebdriver' do
     mswebdriver.remove
@@ -15,10 +16,13 @@ describe Webdrivers::MSWebdriver do
   end
 
   context 'when offline' do
-    before { allow(mswebdriver).to receive(:site_available?).and_return(false) }
+    before do
+      allow(mswebdriver).to receive(:site_available?).and_return(false)
+      mswebdriver.remove
+    end
 
     it 'raises exception downloading' do
-      expect { mswebdriver.download }.to raise_error(StandardError, 'Can not reach site')
+      expect { mswebdriver.download }.to raise_error(StandardError, update_failed_msg)
     end
   end
 end


### PR DESCRIPTION
* Make 0 network calls if user already has desired or latest `chromedriver`. 
* Return currently downloaded version as latest version if update site is down. Also print a warning to the console to let the user we're using the existing driver version.
* Wrap the update failure message in a method for re-usability and consistency.

Partially addresses #29.