### PR TITLE
Add workaround for Jruby double quote bug on Windows.

### DIFF
--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'shellwords'
 
 module Webdrivers
   class Chromedriver < Common
@@ -86,7 +87,16 @@ module Webdrivers
       def chrome_on_windows
         if browser_binary
           Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
-          return `powershell (Get-ItemProperty '#{browser_binary}').VersionInfo.ProductVersion`
+          return `powershell (Get-ItemProperty '#{browser_binary}').VersionInfo.ProductVersion`.strip
+        end
+
+        # Workaround for Google Chrome when using Jruby on Windows.
+        # @see https://github.com/titusfortner/webdrivers/issues/41
+        if RUBY_PLATFORM == 'java' && platform == 'win'
+          ver = "powershell (Get-Item -Path ((Get-ItemProperty \"HKLM:\\Software\\Microsoft" \
+          "\\Windows\\CurrentVersion\\App` Paths\\chrome.exe\").\\'(default)\\'))" \
+          ".VersionInfo.ProductVersion"
+          return `#{ver}`.strip
         end
 
         # Default to Google Chrome

--- a/spec/chromedriver_spec.rb
+++ b/spec/chromedriver_spec.rb
@@ -64,6 +64,18 @@ describe Webdrivers::Chromedriver do
     end
   end
 
+  # Workaround for Google Chrome when using Jruby on Windows.
+  # @see https://github.com/titusfortner/webdrivers/issues/41
+  if RUBY_PLATFORM == 'java' && Selenium::WebDriver::Platform.windows?
+    context 'when using Jruby on Windows' do
+      it 'uses Jruby specific workaround to retrieve the Google Chrome version' do
+        chromedriver.remove
+        chromedriver.update
+        expect(chromedriver.current_version).to_not be_nil
+      end
+    end
+  end
+
   context 'when offline' do
     before { allow(chromedriver).to receive(:site_available?).and_return(false) }
 


### PR DESCRIPTION
Partially fixes #41 - when using Google Chrome with Jruby on Windows. Browser binary path passed through `Selenium::WebDriver::Chrome.path` will need to not have any spaces because of https://github.com/jruby/jruby/issues/3725.

Also required `shellwords` to address https://github.com/titusfortner/webdrivers/commit/95701ed1f0975ca182ae3b7e446da6c4844bec3f#r32941593.