### PR TITLE
Webdrivers.net_http_ssl_fix now raises an exception.

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,8 @@ Add the following to your code:
 require 'net_http_ssl_fix'
 ````
 
+Other solutions are documented on the RubyGems [website](https://guides.rubygems.org/ssl-certificate-update/).
+
 ### Logging
 
 The logging level can be configured for debugging purpose:

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -17,5 +17,10 @@ module Webdrivers
     def configure
       yield self
     end
+
+    def net_http_ssl_fix
+      raise 'Webdrivers.net_http_ssl_fix is no longer available.' \
+      ' Please see https://github.com/titusfortner/webdrivers#ssl_connect-errors.'
+    end
   end
 end

--- a/spec/webdrivers_proxy_support_spec.rb
+++ b/spec/webdrivers_proxy_support_spec.rb
@@ -42,4 +42,10 @@ describe Webdrivers do
   it 'does not use the Proxy when proxy is not configured' do
     expect(http_object.instance_variable_get('@is_proxy_class')).to be false
   end
+
+  it 'raises an exception when net_http_ssl_fix is called.' do
+    err = 'Webdrivers.net_http_ssl_fix is no longer available.' \
+      ' Please see https://github.com/titusfortner/webdrivers#ssl_connect-errors.'
+    expect { described_class.net_http_ssl_fix }.to raise_error(StandardError, err)
+  end
 end


### PR DESCRIPTION
The exception informs the user this fix is no longer available, and points them to https://github.com/titusfortner/webdrivers#ssl_connect-errors.

Also added a link to the RubyGems [guide](https://guides.rubygems.org/ssl-certificate-update/) for SSL certificate related fixes.