### PR TITLE
Add config to disable automatic updates.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,8 @@ Metrics/AbcSize:
   Enabled: false
 Metrics/CyclomaticComplexity:
   Enabled: false
+Metrics/PerceivedComplexity:
+  Enabled: false
 Style/Documentation:
   Enabled: false
 RSpec/ExampleLength:

--- a/README.md
+++ b/README.md
@@ -62,6 +62,22 @@ You can also trigger the update in your code, but it is not required:
 Webdrivers::Chromedriver.update
 ```
 
+### Automatic Updates
+
+Automatic updates are enabled by default, which means `webdrivers` will 
+always check for updates before passing the driver to Selenium. 
+If you do not want this, you can disable automatic updates in your 
+project:
+
+```ruby
+Webdrivers.auto_update = false
+```
+
+If a driver binary does not already exist, the gem will download it
+once and then never check for updates as long you have the updates disabled. 
+When you do want to download an updated driver without altering this 
+setting, simply delete the existing driver binary.
+
 ### Proxy
 
 If there is a proxy between you and the Internet then you will need to configure

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -8,7 +8,8 @@ require 'webdrivers/mswebdriver'
 
 module Webdrivers
   class << self
-    attr_accessor :proxy_addr, :proxy_port, :proxy_user, :proxy_pass, :install_dir
+    attr_accessor :proxy_addr, :proxy_port, :proxy_user,
+                  :proxy_pass, :install_dir, :auto_update
 
     def logger
       @logger ||= Webdrivers::Logger.new

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -77,6 +77,7 @@ module Webdrivers
 
         raise StandardError, 'Failed to find Chrome binary or its version.' if ver.nil? || ver.empty?
 
+        Webdrivers.logger.debug "Browser version: #{ver}"
         # Google Chrome 73.0.3683.75 -> 73.0.3683.75
         ver[/\d+\.\d+\.\d+\.\d+/]
       end

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -54,6 +54,7 @@ module Webdrivers
         raise StandardError, 'Can not reach site' unless site_available?
 
         url = downloads[desired_version]
+        Webdrivers.logger.debug "Downloading #{url}"
         filename = File.basename url
 
         FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
@@ -91,13 +92,31 @@ module Webdrivers
         File.join install_dir, file_name
       end
 
+      #
+      # Returns count of network request made to the base url. Used for debugging
+      # purpose only.
+      #
+      def network_requests
+        @network_requests || 0
+      end
+
+      #
+      # Resets network request count to 0.
+      #
+      def reset_network_requests
+        @network_requests = 0
+      end
+
       protected
 
       def get(url, limit = 10)
         raise StandardError, 'Too many HTTP redirects' if limit.zero?
 
+        @network_requests ||= 0
         response = http.get_response(URI(url))
         Webdrivers.logger.debug "Get response: #{response.inspect}"
+        @network_requests += 1
+        Webdrivers.logger.debug "Successful network request ##{@network_requests}"
 
         case response
         when Net::HTTPSuccess

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -75,6 +75,24 @@ describe Webdrivers::Chromedriver do
     end
   end
 
+  context 'when auto-update is disabled' do
+    before { Webdrivers.auto_update = false }
+
+    it 'downloads the binary if one does not exist' do
+      chromedriver.remove
+      chromedriver.update
+      expect(chromedriver.current_version).not_to be_nil
+    end
+
+    it 'does not make any network calls if a binary exists' do
+      chromedriver.remove
+      chromedriver.update
+      chromedriver.reset_network_requests
+      chromedriver.update
+      expect(chromedriver.network_requests).to be(0)
+    end
+  end
+
   context 'when offline' do
     before { allow(chromedriver).to receive(:site_available?).and_return(false) }
 

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
+  s.add_development_dependency 'ffi' # For selenium_webdriver / childprocess gem on Windows
   s.add_development_dependency 'rake', '~> 10.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~>0.66'


### PR DESCRIPTION
* Add config `Webdrivers.auto_update` to enable/disable automatic updates.
* When set to `true`, which is the default setting, it will always perform an update check before passing the driver to Selenium.
* When set to `false` it disables the update check as long as a driver binary exists. 
* If `Webdrivers.auto_update` is set to `false` and a binary does not exist, it will download the driver once and never check for updates as long as the updates are disabled. This is useful when you do want to update the driver without altering the config in your project - simply delete the existing binary to trigger a one-time update.

Other changes:

* Added network request counter for testing purpose.
* Current Chrome/Chromium version is now printed to the debug log. I forgot to add this in my PR for #38.
* Disabled `Metrics/PerceivedComplexity` in rubocop because this features increases the complexity in `Common#update` from 7 to 9. We can deal with this in the rewrite for v4.
* Added `ffi` as a development dependency. `selenium-webdriver` -> `childprocess` requires it on Windows, but does not list it as a dependency.

**EDIT**: I am now thinking that addition of `ffi` should be its own PR so its easy to track from the commits. Let me know if you have a preference.