### PR TITLE
download chromedriver directly instead of parsing the index

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,19 +1,31 @@
 require: rubocop-rspec
+
 Metrics/LineLength:
-  Enabled: false
+  Max: 120
+
 Metrics/MethodLength:
   Enabled: false
+
 Metrics/BlockLength:
-  Enabled: false
+  Exclude:
+    - 'spec/**/*'
+
 Metrics/ClassLength:
-  Enabled: false
+  Exclude:
+    - 'lib/webdrivers/common.rb'
+
 Metrics/AbcSize:
-  Enabled: false
+  Exclude:
+    - 'lib/webdrivers/common.rb'
+
 Metrics/CyclomaticComplexity:
-  Enabled: false
+  Max: 8
+
 Style/Documentation:
   Enabled: false
+
 RSpec/ExampleLength:
   Enabled: false
+
 RSpec/MultipleExpectations:
   Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in webdrivers.gemspec

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'bundler/gem_tasks'
 require 'rspec/core/rake_task'
 require 'rubocop/rake_task'

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'webdrivers/selenium'
 require 'webdrivers/logger'
 require 'webdrivers/common'

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 require 'shellwords'
 
@@ -40,7 +42,7 @@ module Webdrivers
         'https://chromedriver.storage.googleapis.com'
       end
 
-      def downloads
+      def downloads # rubocop:disable  Metrics/AbcSize
         doc = Nokogiri::XML.parse(get(base_url))
         items = doc.css('Contents Key').collect(&:text)
         items.select! { |item| item.include?(platform) }

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -52,22 +52,22 @@ module Webdrivers
 
       def remove
         Webdrivers.logger.debug "Deleting #{binary}"
+        @download_url = nil
         FileUtils.rm_f binary
       end
 
       def download
         raise StandardError, 'Can not reach site' unless site_available?
 
-        url = downloads[desired_version]
-        filename = File.basename url
+        filename = File.basename download_url
 
         FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
         Dir.chdir install_dir do
           FileUtils.rm_f filename
           File.open(filename, 'wb') do |file|
-            file.print get(url)
+            file.print get(download_url)
           end
-          raise "Could not download #{url}" unless File.exist? filename
+          raise "Could not download #{download_url}" unless File.exist? filename
 
           Webdrivers.logger.debug "Successfully downloaded #{filename}"
           dcf = decompress_file(filename)
@@ -126,6 +126,10 @@ module Webdrivers
       end
 
       private
+
+      def download_url
+        @download_url ||= downloads[desired_version]
+      end
 
       def using_proxy
         Webdrivers.proxy_addr && Webdrivers.proxy_port

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rubygems/package'
 require 'zip'
 
@@ -16,7 +18,8 @@ module Webdrivers
 
         # Can't find desired and no existing binary
         if desired_version.nil?
-          msg = "Unable to find the latest version of #{file_name}; try downloading manually from #{base_url} and place in #{install_dir}"
+          msg = "Unable to find the latest version of #{file_name}; try downloading manually " \
+"from #{base_url} and place in #{install_dir}"
           raise StandardError, msg
         end
 

--- a/lib/webdrivers/geckodriver.rb
+++ b/lib/webdrivers/geckodriver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 
 module Webdrivers
@@ -14,7 +16,7 @@ module Webdrivers
 
       private
 
-      def downloads
+      def downloads # rubocop:disable  Metrics/AbcSize
         doc = Nokogiri::HTML.parse(get(base_url))
         items = doc.css('.py-1 a').collect { |item| item['href'] }
         items.reject! { |item| item.include?('archive') }

--- a/lib/webdrivers/iedriver.rb
+++ b/lib/webdrivers/iedriver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'nokogiri'
 require 'rubygems/version'
 

--- a/lib/webdrivers/logger.rb
+++ b/lib/webdrivers/logger.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'forwardable'
 require 'logger'
 
@@ -50,17 +52,17 @@ module Webdrivers
         @logger.level = severity
       else
         case severity.to_s.downcase
-        when 'debug'.freeze
+        when 'debug'
           @logger.level = DEBUG
-        when 'info'.freeze
+        when 'info'
           @logger.level = INFO
-        when 'warn'.freeze
+        when 'warn'
           @logger.level = WARN
-        when 'error'.freeze
+        when 'error'
           @logger.level = ERROR
-        when 'fatal'.freeze
+        when 'fatal'
           @logger.level = FATAL
-        when 'unknown'.freeze
+        when 'unknown'
           @logger.level = UNKNOWN
         else
           raise ArgumentError, "invalid log level: #{severity}"

--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module Webdrivers
   class MSWebdriver < Common
     class << self

--- a/lib/webdrivers/selenium.rb
+++ b/lib/webdrivers/selenium.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'selenium-webdriver'
 
 # v3.151.59 and higher

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'simplecov'
 SimpleCov.start
 

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Webdrivers::Chromedriver do

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Webdrivers::Geckodriver do
@@ -6,7 +8,8 @@ describe Webdrivers::Geckodriver do
   it 'raises exception if unable to get latest geckodriver and no geckodriver present' do
     geckodriver.remove
     allow(geckodriver).to receive(:desired_version).and_return(nil)
-    msg = /^Unable to find the latest version of geckodriver(.exe)?; try downloading manually from (.*)?and place in (.*)?\.webdrivers$/
+    gd = 'Unable to find the latest version of geckodriver'
+    msg = /^#{gd}(.exe)?; try downloading manually from (.*)?and place in (.*)?\.webdrivers$/
     expect { geckodriver.update }.to raise_exception StandardError, msg
   end
 

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Webdrivers::IEdriver do

--- a/spec/webdrivers/ms_webdriver_spec.rb
+++ b/spec/webdrivers/ms_webdriver_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 describe Webdrivers::MSWebdriver do

--- a/spec/webdrivers_proxy_support_spec.rb
+++ b/spec/webdrivers_proxy_support_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'spec_helper'
 
 class FakeDriver < Webdrivers::Common

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 $LOAD_PATH.push File.expand_path('../lib', __dir__)
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
We shouldn't need to parse the download page when we know the exact file we want from chrome.