### PR TITLE
specify behavior for unmatched drivers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
+  Max: 110
   Exclude:
     - 'lib/webdrivers/common.rb'
 

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -38,7 +38,7 @@ module Webdrivers
         elsif version.nil?
           latest_version
         else
-          Gem::Version.new(version.to_s)
+          normalize_version(version)
         end
       end
 
@@ -206,8 +206,8 @@ module Webdrivers
         desired_version == current_version && File.exist?(binary)
       end
 
-      def normalize(string)
-        Gem::Version.new(string)
+      def normalize_version(version)
+        Gem::Version.new(version.to_s)
       end
     end
   end

--- a/lib/webdrivers/geckodriver.rb
+++ b/lib/webdrivers/geckodriver.rb
@@ -11,7 +11,7 @@ module Webdrivers
 
         string = `#{binary} --version`
         Webdrivers.logger.debug "Current version of #{binary} is #{string}"
-        normalize string.match(/geckodriver (\d+\.\d+\.\d+)/)[1]
+        normalize_version string.match(/geckodriver (\d+\.\d+\.\d+)/)[1]
       end
 
       private
@@ -22,7 +22,7 @@ module Webdrivers
         items.reject! { |item| item.include?('archive') }
         items.select! { |item| item.include?(platform) }
         ds = items.each_with_object({}) do |item, hash|
-          key = normalize item[/v(\d+\.\d+\.\d+)/, 1]
+          key = normalize_version item[/v(\d+\.\d+\.\d+)/, 1]
           hash[key] = "https://github.com#{item}"
         end
         Webdrivers.logger.debug "Versions now located on downloads site: #{ds.keys}"

--- a/lib/webdrivers/iedriver.rb
+++ b/lib/webdrivers/iedriver.rb
@@ -12,7 +12,7 @@ module Webdrivers
 
         string = `#{binary} --version`
         Webdrivers.logger.debug "Current version of #{binary} is #{string}"
-        normalize string.match(/IEDriverServer.exe (\d\.\d+\.\d*\.\d*)/)[1]
+        normalize_version string.match(/IEDriverServer.exe (\d\.\d+\.\d*\.\d*)/)[1]
       end
 
       private
@@ -30,7 +30,7 @@ module Webdrivers
         items = doc.css('Key').collect(&:text)
         items.select! { |item| item.include?('IEDriverServer_Win32') }
         ds = items.each_with_object({}) do |item, hash|
-          key = normalize item[/([^_]+)\.zip/, 1]
+          key = normalize_version item[/([^_]+)\.zip/, 1]
           hash[key] = "#{base_url}#{item}"
         end
         Webdrivers.logger.debug "Versions now located on downloads site: #{ds.keys}"

--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -40,7 +40,7 @@ module Webdrivers
         array.each_with_object({}) do |link, hash|
           next if link.text == 'Insiders'
 
-          key = normalize link.text.scan(/\d+/).first.to_i
+          key = normalize_version link.text.scan(/\d+/).first.to_i
           hash[key] = link['href']
         end
       end

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -10,7 +10,7 @@ describe Webdrivers::Chromedriver do
   end
 
   it 'parses chromedriver versions before 2.10' do
-    expect(chromedriver.send(:normalize, '2.9').version).to eq '2.9'
+    expect(chromedriver.send(:normalize_version, '2.9').version).to eq '2.9'
   end
 
   it 'finds latest version' do
@@ -59,6 +59,29 @@ describe Webdrivers::Chromedriver do
       chromedriver.update
 
       expect(chromedriver.current_version.version[/\d+.\d+/]).to eq('2.46')
+    end
+  end
+
+  context 'when using a Chromium version that does not have an associated driver' do
+    before do
+      chromedriver.remove
+      chromedriver.version = nil
+      chromedriver.instance_variable_set('@latest_version', nil)
+    end
+
+    it 'raises an exception for beta version' do
+      allow(chromedriver).to receive(:chrome_version).and_return('100.0.0')
+      msg = 'you appear to be using a non-production version of Chrome; please set '\
+'`Webdrivers::Chromedriver.version = <desired driver version>` to an known chromedriver version: '\
+'https://chromedriver.storage.googleapis.com/index.html'
+      expect { chromedriver.update }.to raise_exception(StandardError, msg)
+    end
+
+    it 'raises an exception for unknown version' do
+      allow(chromedriver).to receive(:chrome_version).and_return('72.0.0')
+      msg = 'please set `Webdrivers::Chromedriver.version = <desired driver version>` to an known chromedriver '\
+'version: https://chromedriver.storage.googleapis.com/index.html'
+      expect { chromedriver.update }.to raise_exception(StandardError, msg)
     end
   end
 


### PR DESCRIPTION
This is to address #79 

Options to address this are:
1. Raise exception if an associated driver is not found & ask the user to supply the desired version explicitly
2. Use the latest released version with a direct download
3. Parse the DOM of the release page to find the latest beta version and use that

This PR goes with option 1 because I think the likelihood of there being a problem with the mismatch with the other two options is high enough that I'd rather it not be the default and have users wonder why certain tests are failing. If you want to use the latest/greatest beta browser in your testing, you should be able to figure out how to specify the desired version in your code.

Let me know if there is a better way to address this, or if my arguments against failing more gracefully specifically in the case of Chrome aren't useful.

Implementation wise, this changes all of the references to a version to parse into `Gem::Version` instances, which is the only way to ensure comparisons are correct.