### PR TITLE
add specs with updated implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,6 +2,9 @@ require:
   - rubocop-rspec
   - rubocop-performance
 
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
 Layout/EndOfLine:
   EnforcedStyle: lf
 
@@ -18,11 +21,12 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 110
+  Max: 113
   Exclude:
     - 'lib/webdrivers/common.rb'
 
 Metrics/AbcSize:
+  Max: 16
   Exclude:
     - 'lib/webdrivers/common.rb'
 

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'nokogiri'
 require 'shellwords'
 require 'webdrivers/common'
 
@@ -11,19 +10,17 @@ module Webdrivers
         Webdrivers.logger.debug 'Checking current version'
         return nil unless exists?
 
-        ver = `#{binary} --version`
-        Webdrivers.logger.debug "Current #{binary} version: #{ver}"
+        version = binary_version
+        return nil if version.nil?
 
         # Matches 2.46, 2.46.628411 and 73.0.3683.75
-        normalize_version ver[/\d+\.\d+(\.\d+)?(\.\d+)?/]
+        normalize_version version[/\d+\.\d+(\.\d+)?(\.\d+)?/]
       end
 
       def latest_version
         @latest_version ||= begin
-          raise StandardError, 'Can not reach site' unless site_available?
-
           # Versions before 70 do not have a LATEST_RELEASE file
-          return normalize_version('2.46') if release_version < normalize_version('70.0.3538')
+          return normalize_version('2.41') if release_version < normalize_version('70')
 
           latest_applicable = latest_point_release(release_version)
 
@@ -45,7 +42,7 @@ module Webdrivers
           msg = version > latest_release ? 'you appear to be using a non-production version of Chrome; ' : ''
           msg = "#{msg}please set `Webdrivers::Chromedriver.version = <desired driver version>` to an known "\
 'chromedriver version: https://chromedriver.storage.googleapis.com/index.html'
-          raise StandardError, msg
+          raise VersionError, msg
         end
       end
 
@@ -97,7 +94,7 @@ module Webdrivers
                 raise NotImplementedError, 'Your OS is not supported by webdrivers gem.'
               end.chomp
 
-        raise StandardError, 'Failed to find Chrome binary or its version.' if ver.nil? || ver.empty?
+        raise VersionError, 'Failed to find Chrome binary or its version.' if ver.nil? || ver.empty?
 
         Webdrivers.logger.debug "Browser version: #{ver}"
         normalize_version ver[/\d+\.\d+\.\d+\.\d+/] # Google Chrome 73.0.3683.75 -> 73.0.3683.75
@@ -106,7 +103,7 @@ module Webdrivers
       def chrome_on_windows
         if browser_binary
           Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
-          return `powershell (Get-ItemProperty '#{browser_binary}').VersionInfo.ProductVersion`.strip
+          return system_call("powershell (Get-ItemProperty '#{browser_binary}').VersionInfo.ProductVersion").strip
         end
 
         # Workaround for Google Chrome when using Jruby on Windows.
@@ -115,39 +112,39 @@ module Webdrivers
           ver = 'powershell (Get-Item -Path ((Get-ItemProperty "HKLM:\\Software\\Microsoft' \
           "\\Windows\\CurrentVersion\\App` Paths\\chrome.exe\").\\'(default)\\'))" \
           '.VersionInfo.ProductVersion'
-          return `#{ver}`.strip
+          return system_call(ver).strip
         end
 
         # Default to Google Chrome
         reg        = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
-        executable = `powershell (Get-ItemProperty '#{reg}' -Name '(default)').'(default)'`.strip
+        executable = system_call("powershell (Get-ItemProperty '#{reg}' -Name '(default)').'(default)'").strip
         Webdrivers.logger.debug "Browser executable: '#{executable}'"
         ps = "(Get-Item (Get-ItemProperty '#{reg}').'(default)').VersionInfo.ProductVersion"
-        `powershell #{ps}`.strip
+        system_call("powershell #{ps}").strip
       end
 
       def chrome_on_linux
         if browser_binary
           Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
-          return `#{Shellwords.escape browser_binary} --product-version`.strip
+          return system_call("#{Shellwords.escape browser_binary} --product-version").strip
         end
 
         # Default to Google Chrome
-        executable = `which google-chrome`.strip
+        executable = system_call('which google-chrome').strip
         Webdrivers.logger.debug "Browser executable: '#{executable}'"
-        `#{executable} --product-version`.strip
+        system_call("#{executable} --product-version").strip
       end
 
       def chrome_on_mac
         if browser_binary
           Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
-          return `#{Shellwords.escape browser_binary} --version`.strip
+          return system_call("#{Shellwords.escape browser_binary} --version").strip
         end
 
         # Default to Google Chrome
         executable = Shellwords.escape '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
         Webdrivers.logger.debug "Browser executable: #{executable}"
-        `#{executable} --version`.strip
+        system_call("#{executable} --version").strip
       end
 
       #
@@ -156,6 +153,11 @@ module Webdrivers
       def browser_binary
         # For Chromium, Brave, or whatever else
         Selenium::WebDriver::Chrome.path
+      end
+
+      def sufficient_binary?
+        super && current_version && (current_version < normalize_version('70.0.3538') ||
+            current_version.segments.first == release_version.segments.first)
       end
     end
   end

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -6,6 +6,12 @@ require 'webdrivers/logger'
 require 'selenium-webdriver'
 
 module Webdrivers
+  class ConnectionError < StandardError
+  end
+
+  class VersionError < StandardError
+  end
+
   class << self
     attr_accessor :proxy_addr, :proxy_port, :proxy_user, :proxy_pass, :install_dir
 
@@ -21,52 +27,28 @@ module Webdrivers
       raise 'Webdrivers.net_http_ssl_fix is no longer available.' \
       ' Please see https://github.com/titusfortner/webdrivers#ssl_connect-errors.'
     end
-  end
+end
 
   class Common
     class << self
       attr_accessor :version
 
       def update
-        unless site_available?
-          return current_version.nil? ? nil : binary
-        end
-
-        # Newer not specified or latest not found, so use existing
-        return binary if desired_version.nil? && File.exist?(binary)
-
-        # Can't find desired and no existing binary
-        if desired_version.nil?
-          msg = "Unable to find the latest version of #{file_name}; try downloading manually " \
-"from #{base_url} and place in #{install_dir}"
-          raise StandardError, msg
-        end
-
         if correct_binary?
-          Webdrivers.logger.debug 'Expected webdriver version found'
+          Webdrivers.logger.debug 'The required webdriver version is already on the system'
           return binary
         end
 
-        remove # Remove outdated exe
-        download # Fetch latest
+        remove
+        private_download
       end
 
       def desired_version
-        if version.is_a?(Gem::Version)
-          version
-        elsif version.nil?
-          latest_version
-        else
-          normalize_version(version)
-        end
+        version.nil? ? latest_version : normalize_version(version)
       end
 
       def latest_version
-        @latest_version ||= begin
-          raise StandardError, 'Can not reach site' unless site_available?
-
-          downloads.keys.max
-        end
+        @latest_version ||= downloads.keys.max
       end
 
       def remove
@@ -75,6 +57,7 @@ module Webdrivers
         delay         = 0.5
         Webdrivers.logger.debug "Deleting #{binary}"
         @download_url = nil
+        @latest_version = nil
 
         begin
           attempts_made += 1
@@ -87,8 +70,22 @@ module Webdrivers
       end
 
       def download
-        raise StandardError, 'Can not reach site' unless site_available?
+        Webdrivers.logger.deprecate('#download', '#update')
+        private_download
+      end
 
+      def install_dir
+        Webdrivers.install_dir || File.expand_path(File.join(ENV['HOME'], '.webdrivers'))
+      end
+
+      def binary
+        File.join install_dir, file_name
+      end
+
+      private
+
+      # Rename this when deprecating #download as a public method
+      def private_download
         filename = File.basename download_url
 
         FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
@@ -114,20 +111,17 @@ module Webdrivers
         binary
       end
 
-      def install_dir
-        Webdrivers.install_dir || File.expand_path(File.join(ENV['HOME'], '.webdrivers'))
-      end
-
-      def binary
-        File.join install_dir, file_name
-      end
-
-      protected
-
       def get(url, limit = 10)
-        raise StandardError, 'Too many HTTP redirects' if limit.zero?
+        Webdrivers.logger.debug "Getting URL: #{url}"
 
-        response = http.get_response(URI(url))
+        raise ConnectionError, 'Too many HTTP redirects' if limit.zero?
+
+        begin
+          response = http.get_response(URI(url))
+        rescue SocketError
+          raise ConnectionError, "Can not reach #{url}"
+        end
+
         Webdrivers.logger.debug "Get response: #{response.inspect}"
 
         case response
@@ -135,7 +129,7 @@ module Webdrivers
           response.body
         when Net::HTTPRedirection
           location = response['location']
-          Webdrivers.logger.debug "Redirected to #{location}"
+          Webdrivers.logger.debug "Redirected to URL: #{location}"
           get(location, limit - 1)
         else
           response.value
@@ -151,10 +145,8 @@ module Webdrivers
         end
       end
 
-      private
-
       def download_url
-        @download_url ||= downloads[desired_version]
+        @download_url ||= version.nil? ? downloads[downloads.keys.max] : downloads[normalize_version(version)]
       end
 
       def using_proxy
@@ -165,16 +157,6 @@ module Webdrivers
         result = File.exist? binary
         Webdrivers.logger.debug "File already exists: #{result}"
         result
-      end
-
-      def site_available?
-        Webdrivers.logger.debug "Looking for Site: #{base_url}"
-        get(base_url)
-        Webdrivers.logger.debug "Found Site: #{base_url}"
-        true
-      rescue StandardError => e
-        Webdrivers.logger.debug e
-        false
       end
 
       def platform
@@ -227,13 +209,30 @@ module Webdrivers
         @top_path
       end
 
-      # Already have latest version?
       def correct_binary?
-        desired_version == current_version && File.exist?(binary)
+        desired_version == current_version
+      rescue ConnectionError
+        binary if sufficient_binary?
+      end
+
+      def sufficient_binary?
+        exists?
       end
 
       def normalize_version(version)
         Gem::Version.new(version.to_s)
+      end
+
+      def binary_version
+        version = system_call("#{binary} --version")
+        Webdrivers.logger.debug "Current version of #{binary} is #{version}"
+        version
+      rescue Errno::ENOENT
+        nil
+      end
+
+      def system_call(call)
+        `#{call}`
       end
     end
   end

--- a/lib/webdrivers/geckodriver.rb
+++ b/lib/webdrivers/geckodriver.rb
@@ -10,12 +10,21 @@ module Webdrivers
         Webdrivers.logger.debug 'Checking current version'
         return nil unless exists?
 
-        string = `#{binary} --version`
-        Webdrivers.logger.debug "Current version of #{binary} is #{string}"
-        normalize_version string.match(/geckodriver (\d+\.\d+\.\d+)/)[1]
+        version = binary_version
+        return nil if version.nil?
+
+        normalize_version version.match(/geckodriver (\d+\.\d+\.\d+)/)[1]
       end
 
       private
+
+      def file_name
+        platform == 'win' ? 'geckodriver.exe' : 'geckodriver'
+      end
+
+      def base_url
+        'https://github.com/mozilla/geckodriver/releases'
+      end
 
       def downloads # rubocop:disable  Metrics/AbcSize
         doc = Nokogiri::HTML.parse(get(base_url))
@@ -28,14 +37,6 @@ module Webdrivers
         end
         Webdrivers.logger.debug "Versions now located on downloads site: #{ds.keys}"
         ds
-      end
-
-      def file_name
-        platform == 'win' ? 'geckodriver.exe' : 'geckodriver'
-      end
-
-      def base_url
-        'https://github.com/mozilla/geckodriver/releases'
       end
     end
   end

--- a/lib/webdrivers/iedriver.rb
+++ b/lib/webdrivers/iedriver.rb
@@ -11,9 +11,10 @@ module Webdrivers
         Webdrivers.logger.debug 'Checking current version'
         return nil unless exists?
 
-        string = `#{binary} --version`
-        Webdrivers.logger.debug "Current version of #{binary} is #{string}"
-        normalize_version string.match(/IEDriverServer.exe (\d\.\d+\.\d*\.\d*)/)[1]
+        version = binary_version
+        return nil if version.nil?
+
+        normalize_version version.match(/IEDriverServer.exe (\d\.\d+\.\d+)/)[1]
       end
 
       private

--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -20,11 +20,11 @@ module Selenium
 
             def driver_path
               unless Webdrivers::MSWebdriver.ignore
-                Webdrivers.logger.warn 'Microsoft WebDriver for the Edge browser is no longer supported by Webdrivers gem;'\
-          ' Due to changes in Edge implementation, the correct version can no longer be accurately provided. '\
+                Webdrivers.logger.warn 'Microsoft WebDriver for the Edge browser is no longer supported by Webdrivers'\
+          ' gem. Due to changes in Edge implementation, the correct version can no longer be accurately provided. '\
           'Download driver, and specify the location with `Selenium::WebDriver::Edge.driver_path = "/driver/path"`, '\
           'or place it in PATH Environment Variable. '\
-          'Download directions here: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads'\
+          'Download directions here: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads '\
           'To remove this warning in Webdrivers 3.x, set `Webdrivers.MSWebdriver.ignore`'
               end
 
@@ -38,11 +38,11 @@ module Selenium
 
           def driver_path
             unless Webdrivers::MSWebdriver.ignore
-              Webdrivers.logger.warn 'Microsoft WebDriver for the Edge browser is no longer supported by Webdrivers gem;'\
-          ' Due to changes in Edge implementation, the correct version can no longer be accurately provided. '\
+              Webdrivers.logger.warn 'Microsoft WebDriver for the Edge browser is no longer supported by Webdrivers'\
+          ' gem. Due to changes in Edge implementation, the correct version can no longer be accurately provided. '\
           'Download driver, and specify the location with `Selenium::WebDriver::Edge.driver_path = "/driver/path"`, '\
           'or place it in PATH Environment Variable. '\
-          'Download directions here: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads'\
+          'Download directions here: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads '\
           'To remove this warning in Webdrivers 3.x, set `Webdrivers.MSWebdriver.ignore`'
             end
 

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -5,62 +5,171 @@ require 'spec_helper'
 describe Webdrivers::Geckodriver do
   let(:geckodriver) { described_class }
 
-  it 'raises exception if unable to get latest geckodriver and no geckodriver present' do
+  before do
     geckodriver.remove
-    allow(geckodriver).to receive(:desired_version).and_return(nil)
-    gd = 'Unable to find the latest version of geckodriver'
-    msg = /^#{gd}(.exe)?; try downloading manually from (.*)?and place in (.*)?\.webdrivers$/
-    expect { geckodriver.update }.to raise_exception StandardError, msg
+    geckodriver.version = nil
   end
 
-  it 'uses found version of geckodriver if latest release unable to be found' do
-    geckodriver.download
-    allow(geckodriver).to receive(:desired_version).and_return(nil)
-    expect(geckodriver.update).to match(%r{\.webdrivers/geckodriver})
+  describe '#update' do
+    context 'when evaluating #correct_binary?' do
+      it 'does not download when latest version and current version match' do
+        allow(geckodriver).to receive(:latest_version).and_return(Gem::Version.new('0.3.0'))
+        allow(geckodriver).to receive(:current_version).and_return(Gem::Version.new('0.3.0'))
+
+        geckodriver.update
+
+        expect(geckodriver.send(:exists?)).to be false
+      end
+
+      it 'does not download when offline, but binary exists' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(geckodriver).to receive(:exists?).and_return(true)
+
+        geckodriver.update
+
+        expect(File.exist?(geckodriver.binary)).to be false
+      end
+
+      it 'raises ConnectionError when offline, and no binary exists' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(geckodriver).to receive(:exists?).and_return(false)
+
+        expect { geckodriver.update }.to raise_error(Webdrivers::ConnectionError)
+      end
+    end
+
+    context 'when correct binary is found' do
+      before { allow(geckodriver).to receive(:correct_binary?).and_return(true) }
+
+      it 'does not download' do
+        geckodriver.update
+
+        expect(geckodriver.current_version).to be_nil
+      end
+
+      it 'does not raise exception if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        geckodriver.update
+
+        expect(geckodriver.current_version).to be_nil
+      end
+    end
+
+    context 'when correct binary is not found' do
+      before { allow(geckodriver).to receive(:correct_binary?).and_return(false) }
+
+      it 'downloads binary' do
+        geckodriver.update
+
+        expect(geckodriver.current_version).not_to be_nil
+      end
+
+      it 'raises ConnectionError if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        msg = %r{Can not reach https://github.com/mozilla/geckodriver/releases}
+        expect { geckodriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+      end
+    end
   end
 
-  it 'finds latest version' do
-    old_version = Gem::Version.new('0.17')
-    future_version = Gem::Version.new('0.30')
-    desired_version = geckodriver.desired_version
+  describe '#current_version' do
+    it 'returns nil if binary does not exist on the system' do
+      allow(geckodriver).to receive(:binary).and_return('')
 
-    expect(desired_version).to be > old_version
-    expect(desired_version).to be < future_version
+      expect(geckodriver.current_version).to be_nil
+    end
+
+    it 'returns a Gem::Version instance if binary is on the system' do
+      allow(geckodriver).to receive(:exists?).and_return(true)
+
+      return_value = "geckodriver 0.24.0 ( 2019-01-28)
+
+The source code of this program is available from
+testing/geckodriver in https://hg.mozilla.org/mozilla-central.
+
+This program is subject to the terms of the Mozilla Public License 2.0.
+You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
+
+      allow(geckodriver).to receive(:system_call).and_return return_value
+
+      expect(geckodriver.current_version).to eq Gem::Version.new('0.24.0')
+    end
   end
 
-  it 'downloads latest version by default' do
-    geckodriver.download
-    expect(geckodriver.current_version).to eq geckodriver.desired_version
+  describe '#latest_version' do
+    it 'finds the latest version from parsed hash' do
+      base = 'https://github.com/mozilla/geckodriver/releases/download'
+      hash = {Gem::Version.new('0.1.0') => "#{base}/v0.1.0/geckodriver-v0.1.0-macos.tar.gz",
+              Gem::Version.new('0.2.0') => "#{base}/v0.2.0/geckodriver-v0.2.0-macos.tar.gz",
+              Gem::Version.new('0.3.0') => "#{base}/v0.3.0/geckodriver-v0.3.0-macos.tar.gz"}
+      allow(geckodriver).to receive(:downloads).and_return(hash)
+
+      expect(geckodriver.latest_version).to eq Gem::Version.new('0.3.0')
+    end
+
+    it 'correctly parses the downloads page' do
+      expect(geckodriver.send(:downloads)).not_to be_empty
+    end
   end
 
-  it 'downloads specified version' do
-    begin
+  describe '#desired_version' do
+    it 'returns #latest_version if version is not specified' do
+      allow(geckodriver).to receive(:latest_version)
+
+      geckodriver.desired_version
+      expect(geckodriver).to have_received(:latest_version)
+    end
+
+    it 'returns the version specified as a Float' do
+      geckodriver.version = 0.12
+
+      expect(geckodriver.desired_version).to eq Gem::Version.new('0.12')
+    end
+
+    it 'returns the version specified as a String' do
+      geckodriver.version = '0.12.1'
+
+      expect(geckodriver.desired_version).to eq Gem::Version.new('0.12.1')
+    end
+  end
+
+  describe '#remove' do
+    it 'removes existing geckodriver' do
+      geckodriver.update
+
       geckodriver.remove
-      geckodriver.version = '0.17.0'
-      geckodriver.download
-      expect(geckodriver.current_version.version).to eq '0.17.0'
-    ensure
-      geckodriver.version = nil
+      expect(geckodriver.current_version).to be_nil
+    end
+
+    it 'does not raise exception if no geckodriver found' do
+      geckodriver.update
+
+      expect { geckodriver.remove }.not_to raise_error
     end
   end
 
-  it 'removes geckodriver' do
-    geckodriver.remove
-    expect(geckodriver.current_version).to be_nil
+  describe '#install_dir' do
+    it 'uses ~/.webdrivers as default value' do
+      expect(geckodriver.install_dir).to include('.webdriver')
+    end
+
+    it 'uses provided value' do
+      begin
+        install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
+        Webdrivers.install_dir = install_dir
+
+        expect(geckodriver.install_dir).to eq install_dir
+      ensure
+        Webdrivers.install_dir = nil
+      end
+    end
   end
 
-  context 'when offline' do
-    before do
-      geckodriver.instance_variable_set('@latest_version', nil)
-      allow(geckodriver).to receive(:site_available?).and_return(false)
-    end
-
-    it 'raises exception finding latest version' do
-      expect { geckodriver.desired_version }.to raise_error(StandardError, 'Can not reach site')
-    end
-
-    it 'raises exception downloading' do
-      expect { geckodriver.download }.to raise_error(StandardError, 'Can not reach site')
+  describe '#binary' do
+    it 'returns full location of binary' do
+      expect(geckodriver.binary).to match("#{File.join(ENV['HOME'])}/.webdrivers/geckodriver")
     end
   end
 end

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -5,37 +5,165 @@ require 'spec_helper'
 describe Webdrivers::IEdriver do
   let(:iedriver) { described_class }
 
-  it 'finds latest version' do
-    old_version = Gem::Version.new('3.12.0')
-    future_version = Gem::Version.new('4.0')
-    desired_version = iedriver.desired_version
-
-    expect(desired_version).to be > old_version
-    expect(desired_version).to be < future_version
-  end
-
-  it 'downloads iedriver' do
+  before do
     iedriver.remove
-    expect(File.exist?(iedriver.download)).to be true
+    iedriver.version = nil
   end
 
-  it 'removes iedriver' do
-    iedriver.remove
-    expect(iedriver.current_version).to be_nil
-  end
+  describe '#update' do
+    context 'when evaluating #correct_binary?' do
+      it 'does not download when latest version and current version match' do
+        allow(iedriver).to receive(:latest_version).and_return(Gem::Version.new('0.3.0'))
+        allow(iedriver).to receive(:current_version).and_return(Gem::Version.new('0.3.0'))
 
-  context 'when offline' do
-    before do
-      iedriver.instance_variable_set('@latest_version', nil)
-      allow(iedriver).to receive(:site_available?).and_return(false)
+        iedriver.update
+
+        expect(iedriver.send(:exists?)).to be false
+      end
+
+      it 'does not download when offline, but binary exists' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(iedriver).to receive(:exists?).and_return(true)
+
+        iedriver.update
+
+        expect(File.exist?(iedriver.binary)).to be false
+      end
+
+      it 'raises ConnectionError when offline, and no binary exists' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(iedriver).to receive(:exists?).and_return(false)
+
+        expect { iedriver.update }.to raise_error(Webdrivers::ConnectionError)
+      end
     end
 
-    it 'raises exception finding latest version' do
-      expect { iedriver.latest_version }.to raise_error(StandardError, 'Can not reach site')
+    context 'when correct binary is found' do
+      before { allow(iedriver).to receive(:correct_binary?).and_return(true) }
+
+      it 'does not download' do
+        iedriver.update
+
+        expect(iedriver.current_version).to be_nil
+      end
+
+      it 'does not raise exception if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        iedriver.update
+
+        expect(iedriver.current_version).to be_nil
+      end
     end
 
-    it 'raises exception downloading' do
-      expect { iedriver.download }.to raise_error(StandardError, 'Can not reach site')
+    context 'when correct binary is not found' do
+      before { allow(iedriver).to receive(:correct_binary?).and_return(false) }
+
+      it 'downloads binary' do
+        iedriver.update
+
+        expect(File.exist?(iedriver.binary)).to eq true
+      end
+
+      it 'raises ConnectionError if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        msg = %r{Can not reach https://selenium-release.storage.googleapis.com/}
+        expect { iedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+      end
+    end
+  end
+
+  describe '#current_version' do
+    it 'returns nil if binary does not exist on the system' do
+      allow(iedriver).to receive(:binary).and_return('')
+
+      expect(iedriver.current_version).to be_nil
+    end
+
+    it 'returns a Gem::Version instance if binary is on the system' do
+      allow(iedriver).to receive(:exists?).and_return(true)
+
+      return_value = 'something IEDriverServer.exe 3.5.1 something else'
+
+      allow(iedriver).to receive(:system_call).and_return return_value
+
+      expect(iedriver.current_version).to eq Gem::Version.new('3.5.1')
+    end
+  end
+
+  describe '#latest_version' do
+    it 'finds the latest version from parsed hash' do
+      base = 'https://selenium-release.storage.googleapis.com/'
+      hash = {Gem::Version.new('3.4.0') => "#{base}/3.4/IEDriverServer_Win32_3.4.0.zip",
+              Gem::Version.new('3.5.0') => "#{base}/3.5/IEDriverServer_Win32_3.5.0.zip",
+              Gem::Version.new('3.5.1') => "#{base}/3.5/IEDriverServer_Win32_3.5.1.zip"}
+      allow(iedriver).to receive(:downloads).and_return(hash)
+
+      expect(iedriver.latest_version).to eq Gem::Version.new('3.5.1')
+    end
+
+    it 'correctly parses the downloads page' do
+      expect(iedriver.send(:downloads)).not_to be_empty
+    end
+  end
+
+  describe '#desired_version' do
+    it 'returns #latest_version if version is not specified' do
+      allow(iedriver).to receive(:latest_version)
+      iedriver.desired_version
+
+      expect(iedriver).to have_received(:latest_version)
+    end
+
+    it 'returns the version specified as a Float' do
+      iedriver.version = 0.12
+
+      expect(iedriver.desired_version).to eq Gem::Version.new('0.12')
+    end
+
+    it 'returns the version specified as a String' do
+      iedriver.version = '0.12.1'
+
+      expect(iedriver.desired_version).to eq Gem::Version.new('0.12.1')
+    end
+  end
+
+  describe '#remove' do
+    it 'removes existing iedriver' do
+      iedriver.update
+
+      iedriver.remove
+      expect(iedriver.current_version).to be_nil
+    end
+
+    it 'does not raise exception if no iedriver found' do
+      iedriver.update
+
+      expect { iedriver.remove }.not_to raise_error
+    end
+  end
+
+  describe '#install_dir' do
+    it 'uses ~/.webdrivers as default value' do
+      expect(iedriver.install_dir).to include('.webdriver')
+    end
+
+    it 'uses provided value' do
+      begin
+        install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
+        Webdrivers.install_dir = install_dir
+
+        expect(iedriver.install_dir).to eq install_dir
+      ensure
+        Webdrivers.install_dir = nil
+      end
+    end
+  end
+
+  describe '#binary' do
+    it 'returns full location of binary' do
+      expect(iedriver.binary).to eq("#{File.join(ENV['HOME'])}/.webdrivers/IEDriverServer.exe")
     end
   end
 end

--- a/spec/webdrivers_proxy_support_spec.rb
+++ b/spec/webdrivers_proxy_support_spec.rb
@@ -48,6 +48,6 @@ describe Webdrivers do
   it 'raises an exception when net_http_ssl_fix is called.' do
     err = 'Webdrivers.net_http_ssl_fix is no longer available.' \
       ' Please see https://github.com/titusfortner/webdrivers#ssl_connect-errors.'
-    expect { described_class.net_http_ssl_fix }.to raise_error(StandardError, err)
+    expect { described_class.net_http_ssl_fix }.to raise_error(RuntimeError, err)
   end
 end


### PR DESCRIPTION
This would fix #80 

Please make sure that these specs match what you expect. Chrome is a little special, but IE & Firefox are the exact same logic.

~~I updated specs for all of the drivers except for Edge. The existing specs are passing for Edge, but I don't think this code (or existing code works correctly for Edge). I'm going to propose some code changes for that separately before release.~~
I added specs with separate logic for Edge. Things are a little weird with the latest updates: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/
This will need to be updated once we see the pattern that `msedgedriver.exe` takes going forward

1. Adds Custom Errors
2. Minimizes unnecessary network calls
3. Abstracts out a couple methods to make testing easier
4. Chromedriver code is slightly more strict when in offline mode (`#sufficient_binary?`)

Also, I want to release a 3.9 before merging this in.