### PR TITLE
#remove - Fix an intermittent file locking issue on Windows.

### DIFF
--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -51,9 +51,19 @@ module Webdrivers
       end
 
       def remove
+        max_attempts  = 3
+        attempts_made = 0
+        delay         = 0.5
         Webdrivers.logger.debug "Deleting #{binary}"
         @download_url = nil
-        FileUtils.rm_f binary
+
+        begin
+          attempts_made += 1
+          File.delete binary if File.exist? binary
+        rescue Errno::EACCES # Solves an intermittent file locking issue on Windows
+          sleep(delay)
+          retry if File.exist?(binary) && attempts_made <= max_attempts
+        end
       end
 
       def download

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -63,6 +63,7 @@ module Webdrivers
         rescue Errno::EACCES # Solves an intermittent file locking issue on Windows
           sleep(delay)
           retry if File.exist?(binary) && attempts_made <= max_attempts
+          raise
         end
       end
 


### PR DESCRIPTION
Fixes an intermittent file locking issue in specs when `#remove` fails to remove the binary on Windows (Appveyor). The spec expects the file to be removed, but it is not because `FileUtils.rm_f` fails to delete and does not raise any errors.

Example: https://ci.appveyor.com/project/kapoorlakshya/webdrivers/builds/24270606

The solution in this PR is to use `File#delete` and then rescue `Errno::EACCES` and retry up to 3 times.

@twalpole Do you have any suggestions to further improve this? 