### PR TITLE
deprecate MSWebdriver

### DIFF
--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -3,6 +3,14 @@
 module Webdrivers
   class MSWebdriver < Common
     class << self
+      def update
+        old = 'Webdrivers::MSWebdriver'
+        url = 'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads'
+        new = "Microsoft Edge v18+ where the driver is included in the system (see: #{url})"
+        Webdrivers.logger.deprecate(old, new)
+        super
+      end
+
       def windows_version
         Webdrivers.logger.debug 'Checking current version'
 


### PR DESCRIPTION
I'm not certain the current implementation of MSWebdriver works for Edge versions < 17, and I can't get any of my virtual machines to even run the Microsoft Webdriver, let alone validate that the webdrivers gem logic is working. So, I'd like to just deprecate this entire class for webdrivers 4, and then create a new one to support the new Chromium version for 4.0. Note that Selenium 4 will not work with Edge 17 & below.

Any objections to this approach?