### PR TITLE
3.9

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,5 +1,8 @@
 require: rubocop-rspec
 
+Layout/SpaceInsideHashLiteralBraces:
+  EnforcedStyle: no_space
+
 Layout/EndOfLine:
   EnforcedStyle: lf
 
@@ -14,11 +17,12 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 110
+  Max: 112
   Exclude:
     - 'lib/webdrivers/common.rb'
 
 Metrics/AbcSize:
+  Max: 16
   Exclude:
     - 'lib/webdrivers/common.rb'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,7 +17,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 110
+  Max: 115
 
 Metrics/AbcSize:
   Max: 16

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -20,7 +20,7 @@ Metrics/ClassLength:
   Max: 115
 
 Metrics/AbcSize:
-  Max: 16
+  Max: 18
 
 Metrics/CyclomaticComplexity:
   Max: 8

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,14 +17,10 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 112
-  Exclude:
-    - 'lib/webdrivers/common.rb'
+  Max: 110
 
 Metrics/AbcSize:
   Max: 16
-  Exclude:
-    - 'lib/webdrivers/common.rb'
 
 Metrics/CyclomaticComplexity:
   Max: 8

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+### 3.9.0 (2019-05-06)
+* Make public methods more obvious and deprecate unnecessary methods (issue #36)
+* Allow geckodriver binaries to be downloaded directly (issue #30)
+* Allow drivers to be cached to reduce unnecessary network calls (issue #29)
+* MSWebdriver class is deprecated 
+* Refactored to minimize network calls (issue #80)
+
 ### 3.8.1 (2019-05-04)
 * Downloads chromedriver with direct URL instead of parsing the downloads page
 * Raises exception if version of Chrome does not have a known version of the driver (issue #79)

--- a/README.md
+++ b/README.md
@@ -45,16 +45,16 @@ driver will be downloaded and passed to Selenium.
 
 ```ruby
 # Chrome
-Webdrivers::Chromedriver.version = '2.46'
+Webdrivers::Chromedriver.required_version = '2.46'
 
 # Firefox
-Webdrivers::Geckodriver.version  = '0.23.0'
+Webdrivers::Geckodriver.required_version  = '0.23.0'
 
 # Microsoft Internet Explorer
-Webdrivers::IEdriver.version     = '3.14.0'
+Webdrivers::IEdriver.required_version     = '3.14.0'
 
 # Microsoft Edge
-Webdrivers::MSWebdriver.version  = '17134'
+Webdrivers::MSWebdriver.required_version  = '17134'
 ```
 
 You can also trigger the update in your code, but it is not required:
@@ -113,7 +113,7 @@ The version of `chromedriver` will depend on the version of Chrome you are using
 
  * For versions >= 70, the downloaded version of `chromedriver` will match the installed version of Google Chrome. More information [here](http://chromedriver.chromium.org/downloads/version-selection).
  * For versions <=  69, `chromedriver` version 2.46 will be downloaded.
- * For beta versions, you'll have to set the desired beta version of `chromedriver` using `Webdrivers::Chromedriver.version`.
+ * For beta versions, you'll have to set the desired beta version of `chromedriver` using `Webdrivers::Chromedriver.required_version`.
  
 The gem, by default, looks for the Google Chrome version. You can override this by providing a path to the Chromium binary:
 

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -2,10 +2,10 @@
 
 require 'webdrivers/logger'
 require 'webdrivers/common'
-require 'webdrivers/chromedriver'
-require 'webdrivers/geckodriver'
-require 'webdrivers/iedriver'
-require 'webdrivers/mswebdriver'
+require 'webdrivers/drivers/chromedriver'
+require 'webdrivers/drivers/geckodriver'
+require 'webdrivers/drivers/iedriver'
+require 'webdrivers/drivers/mswebdriver'
 require 'webdrivers/selenium'
 
 module Webdrivers

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
-require 'webdrivers/selenium'
 require 'webdrivers/logger'
 require 'webdrivers/common'
 require 'webdrivers/chromedriver'
 require 'webdrivers/geckodriver'
 require 'webdrivers/iedriver'
 require 'webdrivers/mswebdriver'
+require 'webdrivers/selenium'
 
 module Webdrivers
   class ConnectionError < StandardError

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require 'webdrivers/logger'
+require 'webdrivers/network'
 require 'webdrivers/common'
 require 'webdrivers/drivers/chromedriver'
 require 'webdrivers/drivers/geckodriver'

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -2,6 +2,7 @@
 
 require 'webdrivers/logger'
 require 'webdrivers/network'
+require 'webdrivers/system'
 require 'webdrivers/common'
 require 'webdrivers/drivers/chromedriver'
 require 'webdrivers/drivers/geckodriver'

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -9,6 +9,12 @@ require 'webdrivers/iedriver'
 require 'webdrivers/mswebdriver'
 
 module Webdrivers
+  class ConnectionError < StandardError
+  end
+
+  class VersionError < StandardError
+  end
+
   class << self
     attr_accessor :proxy_addr, :proxy_port, :proxy_user, :proxy_pass, :install_dir
 

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -22,7 +22,7 @@ module Webdrivers
     attr_writer :cache_time
 
     def cache_time
-      @cache_time || 86_400
+      @cache_time || 0
     end
 
     def logger

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -19,6 +19,11 @@ module Webdrivers
 
   class << self
     attr_accessor :proxy_addr, :proxy_port, :proxy_user, :proxy_pass, :install_dir
+    attr_writer :cache_time
+
+    def cache_time
+      @cache_time || 86_400
+    end
 
     def logger
       @logger ||= Webdrivers::Logger.new

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -89,7 +89,7 @@ module Webdrivers
         FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
         Dir.chdir install_dir do
           df = Tempfile.open(['', filename], binmode: true) do |file|
-            file.print get(download_url)
+            file.print Network.get(download_url)
             file
           end
 
@@ -109,50 +109,12 @@ module Webdrivers
         driver_path
       end
 
-      def get(url, limit = 10)
-        Webdrivers.logger.debug "Getting URL: #{url}"
-
-        raise ConnectionError, 'Too many HTTP redirects' if limit.zero?
-
-        begin
-          response = http.get_response(URI(url))
-        rescue SocketError
-          raise ConnectionError, "Can not reach #{url}"
-        end
-
-        Webdrivers.logger.debug "Get response: #{response.inspect}"
-
-        case response
-        when Net::HTTPSuccess
-          response.body
-        when Net::HTTPRedirection
-          location = response['location']
-          Webdrivers.logger.debug "Redirected to URL: #{location}"
-          get(location, limit - 1)
-        else
-          response.value
-        end
-      end
-
-      def http
-        if using_proxy
-          Net::HTTP.Proxy(Webdrivers.proxy_addr, Webdrivers.proxy_port,
-                          Webdrivers.proxy_user, Webdrivers.proxy_pass)
-        else
-          Net::HTTP
-        end
-      end
-
       def download_url
         @download_url ||= if required_version.version.empty?
                             downloads[downloads.keys.max]
                           else
                             downloads[normalize_version(required_version)]
                           end
-      end
-
-      def using_proxy
-        Webdrivers.proxy_addr && Webdrivers.proxy_port
       end
 
       def downloaded?

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -19,7 +19,7 @@ module Webdrivers
       end
 
       def required_version
-        Gem::Version.new @required_version
+        normalize_version @required_version
       end
 
       def update
@@ -40,19 +40,16 @@ module Webdrivers
         desired_version.version.empty? ? latest_version : normalize_version(desired_version)
       end
 
-      def latest_version
-        @latest_version ||= downloads.keys.max
-      end
-
       def remove
         @download_url = nil
         @latest_version = nil
+        System.delete "#{System.install_dir}/#{file_name.gsub('.exe', '')}.version"
         System.delete driver_path
       end
 
       def download
         Webdrivers.logger.deprecate('#download', '#update')
-        System.download
+        System.download(download_url, driver_path)
       end
 
       def binary
@@ -94,7 +91,7 @@ module Webdrivers
       end
 
       def normalize_version(version)
-        Gem::Version.new(version.to_s)
+        Gem::Version.new(version.nil? ? nil : version.to_s)
       end
 
       def binary_version

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -29,7 +29,7 @@ module Webdrivers
         end
 
         remove
-        private_download
+        System.download(download_url, driver_path)
       end
 
       def desired_version
@@ -45,30 +45,14 @@ module Webdrivers
       end
 
       def remove
-        max_attempts = 3
-        attempts_made = 0
-        delay = 0.5
-        Webdrivers.logger.debug "Deleting #{driver_path}"
         @download_url = nil
         @latest_version = nil
-
-        begin
-          attempts_made += 1
-          File.delete driver_path if File.exist? driver_path
-        rescue Errno::EACCES # Solves an intermittent file locking issue on Windows
-          sleep(delay)
-          retry if File.exist?(driver_path) && attempts_made <= max_attempts
-          raise
-        end
+        System.delete driver_path
       end
 
       def download
         Webdrivers.logger.deprecate('#download', '#update')
-        private_download
-      end
-
-      def install_dir
-        Webdrivers.install_dir || File.expand_path(File.join(ENV['HOME'], '.webdrivers'))
+        System.download
       end
 
       def binary
@@ -77,37 +61,10 @@ module Webdrivers
       end
 
       def driver_path
-        File.join install_dir, file_name
+        File.join System.install_dir, file_name
       end
 
       private
-
-      # Rename this when deprecating #download as a public method
-      def private_download
-        filename = File.basename download_url
-
-        FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
-        Dir.chdir install_dir do
-          df = Tempfile.open(['', filename], binmode: true) do |file|
-            file.print Network.get(download_url)
-            file
-          end
-
-          raise "Could not download #{download_url}" unless File.exist? df.to_path
-
-          Webdrivers.logger.debug "Successfully downloaded #{df.to_path}"
-
-          decompress_file(df.to_path, filename)
-          Webdrivers.logger.debug 'Decompression Complete'
-          Webdrivers.logger.debug "Deleting #{df.to_path}"
-          df.close!
-        end
-        raise "Could not decompress #{download_url} to get #{driver_path}" unless File.exist?(driver_path)
-
-        FileUtils.chmod 'ugo+rx', driver_path
-        Webdrivers.logger.debug "Completed download and processing of #{driver_path}"
-        driver_path
-      end
 
       def download_url
         @download_url ||= if required_version.version.empty?
@@ -118,59 +75,7 @@ module Webdrivers
       end
 
       def downloaded?
-        result = File.exist? driver_path
-        Webdrivers.logger.debug "File is already downloaded: #{result}"
-        result
-      end
-
-      def platform
-        if Selenium::WebDriver::Platform.linux?
-          "linux#{Selenium::WebDriver::Platform.bitsize}"
-        elsif Selenium::WebDriver::Platform.mac?
-          'mac'
-        else
-          'win'
-        end
-      end
-
-      def decompress_file(filename, target)
-        case filename
-        when /tar\.gz$/
-          Webdrivers.logger.debug 'Decompressing tar'
-          untargz_file(filename)
-        when /tar\.bz2$/
-          Webdrivers.logger.debug 'Decompressing bz2'
-          system "tar xjf #{filename}"
-          filename.gsub('.tar.bz2', '')
-        when /\.zip$/
-          Webdrivers.logger.debug 'Decompressing zip'
-          unzip_file(filename)
-        else
-          Webdrivers.logger.debug 'No Decompression needed'
-          FileUtils.cp(filename, File.join(Dir.pwd, target))
-        end
-      end
-
-      def untargz_file(filename)
-        tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(filename))
-
-        File.open(file_name, 'w+b') do |ucf|
-          tar_extract.each { |entry| ucf << entry.read }
-          File.basename ucf
-        end
-      end
-
-      def unzip_file(filename)
-        Zip::File.open(filename) do |zip_file|
-          zip_file.each do |f|
-            @top_path ||= f.name
-            f_path = File.join(Dir.pwd, f.name)
-            FileUtils.rm_rf(f_path) if File.exist?(f_path)
-            FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))
-            zip_file.extract(f, f_path)
-          end
-        end
-        @top_path
+        System.downloaded? driver_path
       end
 
       # Already have correct version on the system?
@@ -193,15 +98,11 @@ module Webdrivers
       end
 
       def binary_version
-        version = system_call("#{driver_path} --version")
+        version = System.call("#{driver_path} --version")
         Webdrivers.logger.debug "Current version of #{driver_path} is #{version}"
         version
       rescue Errno::ENOENT
         nil
-      end
-
-      def system_call(call)
-        `#{call}`
       end
     end
   end

--- a/lib/webdrivers/drivers/chromedriver.rb
+++ b/lib/webdrivers/drivers/chromedriver.rb
@@ -22,7 +22,13 @@ module Webdrivers
         # Versions before 70 do not have a LATEST_RELEASE file
         return normalize_version('2.41') if release_version < normalize_version('70')
 
-        latest_applicable = latest_point_release(release_version)
+        latest_applicable = if System.valid_cache?(file_name)
+                              System.cached_version(file_name)
+                            else
+                              version = latest_point_release(release_version)
+                              System.cache_version(file_name, version)
+                              version
+                            end
 
         Webdrivers.logger.debug "Latest version available: #{latest_applicable}"
         @latest_version = normalize_version(latest_applicable)

--- a/lib/webdrivers/drivers/chromedriver.rb
+++ b/lib/webdrivers/drivers/chromedriver.rb
@@ -44,7 +44,7 @@ module Webdrivers
         release_file = "LATEST_RELEASE_#{version}"
         begin
           normalize_version(Network.get(URI.join(base_url, release_file)))
-        rescue Net::HTTPServerException
+        rescue StandardError
           latest_release = normalize_version(Network.get(URI.join(base_url, 'LATEST_RELEASE')))
           Webdrivers.logger.debug "Unable to find a driver for: #{version}"
 

--- a/lib/webdrivers/drivers/chromedriver.rb
+++ b/lib/webdrivers/drivers/chromedriver.rb
@@ -43,9 +43,9 @@ module Webdrivers
       def latest_point_release(version)
         release_file = "LATEST_RELEASE_#{version}"
         begin
-          normalize_version(get(URI.join(base_url, release_file)))
+          normalize_version(Network.get(URI.join(base_url, release_file)))
         rescue Net::HTTPServerException
-          latest_release = normalize_version(get(URI.join(base_url, 'LATEST_RELEASE')))
+          latest_release = normalize_version(Network.get(URI.join(base_url, 'LATEST_RELEASE')))
           Webdrivers.logger.debug "Unable to find a driver for: #{version}"
 
           msg = version > latest_release ? 'you appear to be using a non-production version of Chrome; ' : ''

--- a/lib/webdrivers/drivers/chromedriver.rb
+++ b/lib/webdrivers/drivers/chromedriver.rb
@@ -25,6 +25,8 @@ module Webdrivers
         latest_applicable = if System.valid_cache?(file_name)
                               System.cached_version(file_name)
                             else
+                              Webdrivers.logger.warn 'Driver caching is turned off in this version, but will '\
+                              'be enabled by default in 4.x. Set the value now with `Webdrivers#cache_time=` in seconds'
                               version = latest_point_release(release_version)
                               System.cache_version(file_name, version)
                               version

--- a/lib/webdrivers/drivers/chromedriver.rb
+++ b/lib/webdrivers/drivers/chromedriver.rb
@@ -30,7 +30,7 @@ module Webdrivers
 
       # Returns currently installed Chrome version
       def chrome_version
-        ver = send("chrome_on#{platform}").chomp
+        ver = send("chrome_on_#{System.platform}").chomp
 
         raise VersionError, 'Failed to find Chrome binary or its version.' if ver.nil? || ver.empty?
 
@@ -55,20 +55,8 @@ module Webdrivers
         end
       end
 
-      def platform
-        if Selenium::WebDriver::Platform.linux?
-          'linux64'
-        elsif Selenium::WebDriver::Platform.mac?
-          'mac64'
-        elsif Selenium::WebDriver::Platform.windows?
-          'win32'
-        else
-          raise NotImplementedError, 'Your OS is not supported by webdrivers gem.'
-        end
-      end
-
       def file_name
-        Selenium::WebDriver::Platform.windows? ? 'chromedriver.exe' : 'chromedriver'
+        System.platform == 'win' ? 'chromedriver.exe' : 'chromedriver'
       end
 
       def base_url
@@ -84,7 +72,8 @@ module Webdrivers
                     normalize_version(required_version)
                   end
 
-        url = "#{base_url}/#{version}/chromedriver_#{platform}.zip"
+        file_name = System.platform == 'win' ? 'windows32' : "#{System.platform}64"
+        url = "#{base_url}/#{version}/chromedriver_#{file_name}.zip"
         Webdrivers.logger.debug "chromedriver URL: #{url}"
         @download_url = url
       end
@@ -98,10 +87,10 @@ module Webdrivers
         normalize_version(chrome.segments[0..2].join('.'))
       end
 
-      def chrome_on_win32
+      def chrome_on_win
         if browser_binary
           Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
-          return system_call("powershell (Get-ItemProperty '#{browser_binary}').VersionInfo.ProductVersion").strip
+          return System.call("powershell (Get-ItemProperty '#{browser_binary}').VersionInfo.ProductVersion").strip
         end
 
         # Workaround for Google Chrome when using Jruby on Windows.
@@ -110,39 +99,39 @@ module Webdrivers
           ver = 'powershell (Get-Item -Path ((Get-ItemProperty "HKLM:\\Software\\Microsoft' \
           "\\Windows\\CurrentVersion\\App` Paths\\chrome.exe\").\\'(default)\\'))" \
           '.VersionInfo.ProductVersion'
-          return system_call(ver).strip
+          return System.call(ver).strip
         end
 
         # Default to Google Chrome
         reg = 'HKLM:\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
-        executable = system_call("powershell (Get-ItemProperty '#{reg}' -Name '(default)').'(default)'").strip
+        executable = System.call("powershell (Get-ItemProperty '#{reg}' -Name '(default)').'(default)'").strip
         Webdrivers.logger.debug "Browser executable: '#{executable}'"
         ps = "(Get-Item (Get-ItemProperty '#{reg}').'(default)').VersionInfo.ProductVersion"
-        system_call("powershell #{ps}").strip
+        System.call("powershell #{ps}").strip
       end
 
-      def chrome_on_linux64
+      def chrome_on_linux
         if browser_binary
           Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
-          return system_call("#{Shellwords.escape browser_binary} --product-version").strip
+          return System.call("#{Shellwords.escape browser_binary} --product-version").strip
         end
 
         # Default to Google Chrome
-        executable = system_call('which google-chrome').strip
+        executable = System.call('which google-chrome').strip
         Webdrivers.logger.debug "Browser executable: '#{executable}'"
-        system_call("#{executable} --product-version").strip
+        System.call("#{executable} --product-version").strip
       end
 
-      def chrome_on_mac64
+      def chrome_on_mac
         if browser_binary
           Webdrivers.logger.debug "Browser executable: '#{browser_binary}'"
-          return system_call("#{Shellwords.escape browser_binary} --version").strip
+          return System.call("#{Shellwords.escape browser_binary} --version").strip
         end
 
         # Default to Google Chrome
         executable = Shellwords.escape '/Applications/Google Chrome.app/Contents/MacOS/Google Chrome'
         Webdrivers.logger.debug "Browser executable: #{executable}"
-        system_call("#{executable} --version").strip
+        System.call("#{executable} --version").strip
       end
 
       #

--- a/lib/webdrivers/drivers/geckodriver.rb
+++ b/lib/webdrivers/drivers/geckodriver.rb
@@ -26,7 +26,7 @@ module Webdrivers
       end
 
       def downloads # rubocop:disable  Metrics/AbcSize
-        doc = Nokogiri::HTML.parse(get(base_url))
+        doc = Nokogiri::HTML.parse(Network.get(base_url))
         items = doc.css('.py-1 a').collect { |item| item['href'] }
         items.reject! { |item| item.include?('archive') }
         items.select! { |item| item.include?(platform) }

--- a/lib/webdrivers/drivers/geckodriver.rb
+++ b/lib/webdrivers/drivers/geckodriver.rb
@@ -16,7 +16,13 @@ module Webdrivers
       end
 
       def latest_version
-        @latest_version ||= Gem::Version.new(Network.get_url("#{base_url}/latest")[/[^v]*$/])
+        @latest_version ||= if System.valid_cache?(file_name)
+                              normalize_version System.cached_version(file_name)
+                            else
+                              version = normalize_version(Network.get_url("#{base_url}/latest")[/[^v]*$/])
+                              System.cache_version(file_name, version)
+                              version
+                            end
       end
 
       private

--- a/lib/webdrivers/drivers/geckodriver.rb
+++ b/lib/webdrivers/drivers/geckodriver.rb
@@ -18,7 +18,7 @@ module Webdrivers
       private
 
       def file_name
-        platform == 'win' ? 'geckodriver.exe' : 'geckodriver'
+        System.platform == 'win' ? 'geckodriver.exe' : 'geckodriver'
       end
 
       def base_url
@@ -29,6 +29,7 @@ module Webdrivers
         doc = Nokogiri::HTML.parse(Network.get(base_url))
         items = doc.css('.py-1 a').collect { |item| item['href'] }
         items.reject! { |item| item.include?('archive') }
+        platform = System.platform == 'linux' ? "linux#{System.bitsize}" : System.platform
         items.select! { |item| item.include?(platform) }
         ds = items.each_with_object({}) do |item, hash|
           key = normalize_version item[/v(\d+\.\d+\.\d+)/, 1]

--- a/lib/webdrivers/drivers/geckodriver.rb
+++ b/lib/webdrivers/drivers/geckodriver.rb
@@ -19,6 +19,8 @@ module Webdrivers
         @latest_version ||= if System.valid_cache?(file_name)
                               normalize_version System.cached_version(file_name)
                             else
+                              Webdrivers.logger.warn 'Driver caching is turned off in this version, but will '\
+                              'be enabled by default in 4.x. Set the value now with `Webdrivers#cache_time=` in seconds'
                               version = normalize_version(Network.get_url("#{base_url}/latest")[/[^v]*$/])
                               System.cache_version(file_name, version)
                               version

--- a/lib/webdrivers/drivers/iedriver.rb
+++ b/lib/webdrivers/drivers/iedriver.rb
@@ -15,6 +15,16 @@ module Webdrivers
         normalize_version version.match(/IEDriverServer.exe (\d\.\d+\.\d+)/)[1]
       end
 
+      def latest_version
+        @latest_version ||= if System.valid_cache?(file_name)
+                              normalize_version(System.cached_version(file_name))
+                            else
+                              version = downloads.keys.max
+                              System.cache_version(file_name, version)
+                              version
+                            end
+      end
+
       private
 
       def file_name

--- a/lib/webdrivers/drivers/iedriver.rb
+++ b/lib/webdrivers/drivers/iedriver.rb
@@ -26,7 +26,7 @@ module Webdrivers
       end
 
       def downloads
-        doc = Nokogiri::XML.parse(get(base_url))
+        doc = Nokogiri::XML.parse(Network.get(base_url))
         items = doc.css('Key').collect(&:text)
         items.select! { |item| item.include?('IEDriverServer_Win32') }
         ds = items.each_with_object({}) do |item, hash|

--- a/lib/webdrivers/drivers/iedriver.rb
+++ b/lib/webdrivers/drivers/iedriver.rb
@@ -19,6 +19,8 @@ module Webdrivers
         @latest_version ||= if System.valid_cache?(file_name)
                               normalize_version(System.cached_version(file_name))
                             else
+                              Webdrivers.logger.warn 'Driver caching is turned off in this version, but will '\
+                              'be enabled by default in 4.x. Set the value now with `Webdrivers#cache_time=` in seconds'
                               version = downloads.keys.max
                               System.cache_version(file_name, version)
                               version

--- a/lib/webdrivers/drivers/mswebdriver.rb
+++ b/lib/webdrivers/drivers/mswebdriver.rb
@@ -18,7 +18,7 @@ module Webdrivers
         # Unfortunately, MicrosoftWebDriver.exe does not have an option to get the version.
         # To work around it we query the currently installed version of Microsoft Edge instead
         # and compare it to the list of available downloads.
-        version = system_call('powershell (Get-AppxPackage -Name Microsoft.MicrosoftEdge).Version')
+        version = System.call('powershell (Get-AppxPackage -Name Microsoft.MicrosoftEdge).Version')
         raise VersionError, 'Failed to check Microsoft Edge version' if version.empty? # Package name changed?
 
         Webdrivers.logger.debug "Current version of Microsoft Edge is #{version}"

--- a/lib/webdrivers/drivers/mswebdriver.rb
+++ b/lib/webdrivers/drivers/mswebdriver.rb
@@ -23,7 +23,7 @@ module Webdrivers
 
         Webdrivers.logger.debug "Current version of Microsoft Edge is #{version}"
 
-        @windows_version = Gem::Version.new(version)
+        @windows_version = normalize_version(version)
       end
 
       def latest_version
@@ -40,7 +40,7 @@ module Webdrivers
 
         Webdrivers.logger.debug "Desired build of Microsoft WebDriver is #{version}"
 
-        @latest_version = Gem::Version.new(version)
+        @latest_version = normalize_version(version)
       end
 
       private
@@ -54,7 +54,7 @@ module Webdrivers
       end
 
       def download_url
-        @download_url ||= downloads[Gem::Version.new windows_version.segments[1]]
+        @download_url ||= downloads[normalize_version windows_version.segments[1]]
       end
 
       def downloads

--- a/lib/webdrivers/drivers/mswebdriver.rb
+++ b/lib/webdrivers/drivers/mswebdriver.rb
@@ -58,7 +58,7 @@ module Webdrivers
       end
 
       def downloads
-        array = Nokogiri::HTML(get(base_url)).xpath("//li[@class='driver-download']/a")
+        array = Nokogiri::HTML(Network.get(base_url)).xpath("//li[@class='driver-download']/a")
         array.each_with_object({}) do |link, hash|
           next if link.text == 'Insiders'
 
@@ -69,7 +69,7 @@ module Webdrivers
 
       # Assume we have the latest if we are offline and file exists
       def correct_binary?
-        get(base_url)
+        Network.get(base_url)
         false
       rescue ConnectionError
         File.exist?(driver_path)

--- a/lib/webdrivers/drivers/mswebdriver.rb
+++ b/lib/webdrivers/drivers/mswebdriver.rb
@@ -7,6 +7,14 @@ module Webdrivers
     class << self
       attr_accessor :ignore
 
+      def update
+        old = 'Webdrivers::MSWebdriver'
+        url = 'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads'
+        new = "Microsoft Edge v18+ where the driver is included in the system (see: #{url})"
+        Webdrivers.logger.deprecate(old, new)
+        super
+      end
+
       def current_version
         raise NotImplementedError, 'Unable to programatically determine the version of most MicrosoftWebDriver.exe'
       end

--- a/lib/webdrivers/geckodriver.rb
+++ b/lib/webdrivers/geckodriver.rb
@@ -9,12 +9,21 @@ module Webdrivers
         Webdrivers.logger.debug 'Checking current version'
         return nil unless downloaded?
 
-        string = `#{binary} --version`
-        Webdrivers.logger.debug "Current version of #{binary} is #{string}"
-        normalize_version string.match(/geckodriver (\d+\.\d+\.\d+)/)[1]
+        version = binary_version
+        return nil if version.nil?
+
+        normalize_version version.match(/geckodriver (\d+\.\d+\.\d+)/)[1]
       end
 
       private
+
+      def file_name
+        platform == 'win' ? 'geckodriver.exe' : 'geckodriver'
+      end
+
+      def base_url
+        'https://github.com/mozilla/geckodriver/releases'
+      end
 
       def downloads # rubocop:disable  Metrics/AbcSize
         doc = Nokogiri::HTML.parse(get(base_url))
@@ -27,14 +36,6 @@ module Webdrivers
         end
         Webdrivers.logger.debug "Versions now located on downloads site: #{ds.keys}"
         ds
-      end
-
-      def file_name
-        platform == 'win' ? 'geckodriver.exe' : 'geckodriver'
-      end
-
-      def base_url
-        'https://github.com/mozilla/geckodriver/releases'
       end
     end
   end

--- a/lib/webdrivers/iedriver.rb
+++ b/lib/webdrivers/iedriver.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'nokogiri'
-require 'rubygems/version'
 
 module Webdrivers
   class IEdriver < Common
@@ -10,9 +9,10 @@ module Webdrivers
         Webdrivers.logger.debug 'Checking current version'
         return nil unless downloaded?
 
-        string = `#{binary} --version`
-        Webdrivers.logger.debug "Current version of #{binary} is #{string}"
-        normalize_version string.match(/IEDriverServer.exe (\d\.\d+\.\d*\.\d*)/)[1]
+        version = binary_version
+        return nil if version.nil?
+
+        normalize_version version.match(/IEDriverServer.exe (\d\.\d+\.\d+)/)[1]
       end
 
       private

--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'nokogiri'
+
 module Webdrivers
   class MSWebdriver < Common
     class << self
@@ -10,14 +12,14 @@ module Webdrivers
         # Unfortunately, MicrosoftWebDriver.exe does not have an option to get the version.
         # To work around it we query the currently installed version of Microsoft Edge instead
         # and compare it to the list of available downloads.
-        version = `powershell (Get-AppxPackage -Name Microsoft.MicrosoftEdge).Version`
+        version = system_call('powershell (Get-AppxPackage -Name Microsoft.MicrosoftEdge).Version')
         raise 'Failed to check Microsoft Edge version.' if version.empty? # Package name changed?
 
-        Webdrivers.logger.debug "Current version of Microsoft Edge is #{version.chomp!}"
+        Webdrivers.logger.debug "Current version of Microsoft Edge is #{version.dup.chomp!}"
 
         build = version.split('.')[1] # "41.16299.248.0" => "16299"
         Webdrivers.logger.debug "Expecting MicrosoftWebDriver.exe version #{build}"
-        build.to_i
+        Gem::Version.new(build)
       end
 
       # Webdriver binaries for Microsoft Edge are not backwards compatible.
@@ -35,6 +37,14 @@ module Webdrivers
         'MicrosoftWebDriver.exe'
       end
 
+      def base_url
+        'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
+      end
+
+      def download_url
+        @download_url ||= downloads[windows_version]
+      end
+
       def downloads
         array = Nokogiri::HTML(get(base_url)).xpath("//li[@class='driver-download']/a")
         array.each_with_object({}) do |link, hash|
@@ -43,16 +53,6 @@ module Webdrivers
           key = normalize_version link.text.scan(/\d+/).first.to_i
           hash[key] = link['href']
         end
-      end
-
-      def base_url
-        'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
-      end
-
-      # Assume we have the latest if file exists since MicrosoftWebdriver.exe does not have an
-      # argument to check the current version.
-      def correct_binary?
-        File.exist?(binary)
       end
     end
   end

--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -72,7 +72,7 @@ module Webdrivers
         get(base_url)
         false
       rescue ConnectionError
-        File.exist?(binary)
+        File.exist?(driver_path)
       end
     end
   end

--- a/lib/webdrivers/network.rb
+++ b/lib/webdrivers/network.rb
@@ -4,16 +4,20 @@ module Webdrivers
   class Network
     class << self
       def get(url, limit = 10)
+        Webdrivers.logger.debug "Making network call to #{url}"
+
         response = get_response(url, limit)
         case response
         when Net::HTTPSuccess
           response.body
         else
-          response.value
+          raise StandardError, "#{response.class::EXCEPTION_TYPE}: #{response.code} \"#{response.message}\" with #{url}"
         end
       end
 
       def get_url(url, limit = 10)
+        Webdrivers.logger.debug "Making network call to #{url}"
+
         get_response(url, limit).uri.to_s
       end
 

--- a/lib/webdrivers/network.rb
+++ b/lib/webdrivers/network.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Webdrivers
+  class Network
+    class << self
+      def get(url, limit = 10)
+        Webdrivers.logger.debug "Getting URL: #{url}"
+
+        raise ConnectionError, 'Too many HTTP redirects' if limit.zero?
+
+        begin
+          response = http.get_response(URI(url))
+        rescue SocketError
+          raise ConnectionError, "Can not reach #{url}"
+        end
+
+        Webdrivers.logger.debug "Get response: #{response.inspect}"
+
+        case response
+        when Net::HTTPSuccess
+          response.body
+        when Net::HTTPRedirection
+          location = response['location']
+          Webdrivers.logger.debug "Redirected to URL: #{location}"
+          get(location, limit - 1)
+        else
+          response.value
+        end
+      end
+
+      def http
+        if using_proxy
+          Net::HTTP.Proxy(Webdrivers.proxy_addr, Webdrivers.proxy_port,
+                          Webdrivers.proxy_user, Webdrivers.proxy_pass)
+        else
+          Net::HTTP
+        end
+      end
+
+      def using_proxy
+        Webdrivers.proxy_addr && Webdrivers.proxy_port
+      end
+    end
+  end
+end

--- a/lib/webdrivers/selenium.rb
+++ b/lib/webdrivers/selenium.rb
@@ -6,8 +6,10 @@ require 'selenium-webdriver'
 if ::Selenium::WebDriver::Service.respond_to? :driver_path=
   ::Selenium::WebDriver::Chrome::Service.driver_path  = proc { ::Webdrivers::Chromedriver.update }
   ::Selenium::WebDriver::Firefox::Service.driver_path = proc { ::Webdrivers::Geckodriver.update }
-  ::Selenium::WebDriver::Edge::Service.driver_path    = proc { ::Webdrivers::MSWebdriver.update }
   ::Selenium::WebDriver::IE::Service.driver_path      = proc { ::Webdrivers::IEdriver.update }
+  unless Webdrivers::MSWebdriver.ignore
+    ::Selenium::WebDriver::Edge::Service.driver_path = proc { ::Webdrivers::MSWebdriver.update }
+  end
 else
   # v3.141.0 and lower
   module Selenium

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -1,0 +1,131 @@
+# frozen_string_literal: true
+
+require 'rubygems/package'
+require 'zip'
+
+module Webdrivers
+  class System
+    class << self
+      def delete(file)
+        max_attempts = 3
+        attempts_made = 0
+        delay = 0.5
+        Webdrivers.logger.debug "Deleting #{file}"
+
+        begin
+          attempts_made += 1
+          File.delete file if File.exist? file
+        rescue Errno::EACCES # Solves an intermittent file locking issue on Windows
+          sleep(delay)
+          retry if File.exist?(file) && attempts_made <= max_attempts
+          raise
+        end
+      end
+
+      def install_dir
+        Webdrivers.install_dir || File.expand_path(File.join(ENV['HOME'], '.webdrivers'))
+      end
+
+      def download(url, target)
+        FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
+
+        download_file(url, target)
+
+        FileUtils.chmod 'ugo+rx', target
+        Webdrivers.logger.debug "Completed download and processing of #{target}"
+        target
+      end
+
+      def download_file(url, target)
+        file_name = File.basename(url)
+        Dir.chdir(install_dir) do
+          tempfile = Tempfile.open(['', file_name], binmode: true) do |file|
+            file.print Network.get(url)
+            file
+          end
+
+          raise "Could not download #{url}" unless File.exist?(tempfile.to_path)
+
+          Webdrivers.logger.debug "Successfully downloaded #{tempfile.to_path}"
+
+          decompress_file(tempfile, file_name, target)
+          tempfile.close!
+        end
+      end
+
+      def downloaded?(file)
+        result = File.exist? file
+        Webdrivers.logger.debug "#{file} is#{' not' unless result} already downloaded"
+        result
+      end
+
+      def decompress_file(tempfile, file_name, target)
+        tempfile = tempfile.to_path
+        case tempfile
+        when /tar\.gz$/
+          untargz_file(tempfile, File.basename(target))
+        when /tar\.bz2$/
+          untarbz2_file(tempfile)
+        when /\.zip$/
+          unzip_file(tempfile)
+        else
+          Webdrivers.logger.debug 'No Decompression needed'
+          FileUtils.cp(tempfile, File.join(Dir.pwd, file_name))
+        end
+        raise "Could not decompress #{url} to get #{target}" unless File.exist?(target)
+      end
+
+      def untarbz2_file(filename)
+        Webdrivers.logger.debug "Decompressing #{filename}"
+
+        call("tar xjf #{filename}").gsub('.tar.bz2', '')
+      end
+
+      def untargz_file(source, target)
+        Webdrivers.logger.debug "Decompressing #{source}"
+
+        tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(source))
+
+        File.open(target, 'w+b') do |ucf|
+          tar_extract.each { |entry| ucf << entry.read }
+          File.basename ucf
+        end
+      end
+
+      def unzip_file(filename)
+        Webdrivers.logger.debug "Decompressing #{filename}"
+
+        Zip::File.open(filename) do |zip_file|
+          zip_file.each do |f|
+            @top_path ||= f.name
+            f_path = File.join(Dir.pwd, f.name)
+            FileUtils.rm_rf(f_path) if File.exist?(f_path)
+            FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))
+            zip_file.extract(f, f_path)
+          end
+        end
+        @top_path
+      end
+
+      def platform
+        if Selenium::WebDriver::Platform.linux?
+          'linux'
+        elsif Selenium::WebDriver::Platform.mac?
+          'mac'
+        elsif Selenium::WebDriver::Platform.windows?
+          'win'
+        else
+          raise NotImplementedError, 'Your OS is not supported by webdrivers gem.'
+        end
+      end
+
+      def bitsize
+        Selenium::WebDriver::Platform.bitsize
+      end
+
+      def call(cmd)
+        `#{cmd}`
+      end
+    end
+  end
+end

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -26,6 +26,25 @@ module Webdrivers
         Webdrivers.install_dir || File.expand_path(File.join(ENV['HOME'], '.webdrivers'))
       end
 
+      def cache_version(file_name, version)
+        FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
+
+        File.open("#{install_dir}/#{file_name.gsub('.exe', '')}.version", 'w+') do |file|
+          file.print(version)
+        end
+      end
+
+      def cached_version(file_name)
+        File.open("#{install_dir}/#{file_name.gsub('.exe', '')}.version", 'r', &:read)
+      end
+
+      def valid_cache?(file_name)
+        file = "#{install_dir}/#{file_name.gsub('.exe', '')}.version"
+        return false unless File.exist?(file)
+
+        Time.now - File.mtime(file) < Webdrivers.cache_time
+      end
+
       def download(url, target)
         FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
 

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -106,7 +106,9 @@ describe Webdrivers::Chromedriver do
 
     it 'returns a Gem::Version instance if binary is on the system' do
       allow(chromedriver).to receive(:downloaded?).and_return(true)
-      allow(chromedriver).to receive(:system_call).and_return '71.0.3578.137'
+      allow(Webdrivers::System).to receive(:call)
+        .with("#{chromedriver.driver_path} --version")
+        .and_return '71.0.3578.137'
 
       expect(chromedriver.current_version).to eq Gem::Version.new('71.0.3578.137')
     end
@@ -181,7 +183,7 @@ describe Webdrivers::Chromedriver do
 
   describe '#install_dir' do
     it 'uses ~/.webdrivers as default value' do
-      expect(chromedriver.install_dir).to include('.webdriver')
+      expect(Webdrivers::System.install_dir).to include('.webdriver')
     end
 
     it 'uses provided value' do
@@ -189,7 +191,7 @@ describe Webdrivers::Chromedriver do
         install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
         Webdrivers.install_dir = install_dir
 
-        expect(chromedriver.install_dir).to eq install_dir
+        expect(Webdrivers::System.install_dir).to eq install_dir
       ensure
         Webdrivers.install_dir = nil
       end

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -5,125 +5,207 @@ require 'spec_helper'
 describe Webdrivers::Chromedriver do
   let(:chromedriver) { described_class }
 
-  it 'updates' do
-    chromedriver.update
-  end
-
-  it 'parses chromedriver versions before 2.10' do
-    expect(chromedriver.send(:normalize_version, '2.9').version).to eq '2.9'
-  end
-
-  it 'finds latest version' do
-    old_version = Gem::Version.new('2.30')
-    future_version = Gem::Version.new('80.00')
-    latest_version = chromedriver.latest_version
-
-    expect(latest_version).to be > old_version
-    expect(latest_version).to be < future_version
-  end
-
-  it 'downloads latest release for current version of Chrome by default' do
+  before do
     chromedriver.remove
-    chromedriver.download
-    cur_ver    = chromedriver.current_version.version
-    latest_ver = chromedriver.latest_version.version
-    expect(cur_ver).to eq latest_ver
+    chromedriver.version = nil
   end
 
-  it 'downloads specified version by Float' do
-    chromedriver.remove
-    chromedriver.version = 2.29
-    chromedriver.download
-    expect(chromedriver.current_version.version).to include '2.29'
-  end
+  describe '#update' do
+    context 'when evaluating #correct_binary?' do
+      it 'does not download when latest version and current version match' do
+        allow(chromedriver).to receive(:latest_version).and_return(Gem::Version.new('72.0.0'))
+        allow(chromedriver).to receive(:current_version).and_return(Gem::Version.new('72.0.0'))
 
-  it 'downloads specified version by String' do
-    chromedriver.remove
-    chromedriver.version = '73.0.3683.68'
-    chromedriver.download
-    expect(chromedriver.current_version.version).to eq '73.0.3683.68'
-  end
-
-  it 'removes chromedriver' do
-    chromedriver.remove
-    expect(chromedriver.current_version).to be_nil
-  end
-
-  context 'when using a Chromium version < 70.0.3538' do
-    it 'downloads chromedriver 2.46' do
-      chromedriver.remove
-      chromedriver.version = nil
-      chromedriver.instance_variable_set('@latest_version', nil)
-
-      allow(chromedriver).to receive(:chrome_version).and_return('70.0.0')
-      chromedriver.update
-
-      expect(chromedriver.current_version.version[/\d+.\d+/]).to eq('2.46')
-    end
-  end
-
-  context 'when using a Chromium version that does not have an associated driver' do
-    before do
-      chromedriver.remove
-      chromedriver.version = nil
-      chromedriver.instance_variable_set('@latest_version', nil)
-    end
-
-    it 'raises an exception for beta version' do
-      allow(chromedriver).to receive(:chrome_version).and_return('100.0.0')
-      msg = 'you appear to be using a non-production version of Chrome; please set '\
-'`Webdrivers::Chromedriver.version = <desired driver version>` to an known chromedriver version: '\
-'https://chromedriver.storage.googleapis.com/index.html'
-      expect { chromedriver.update }.to raise_exception(StandardError, msg)
-    end
-
-    it 'raises an exception for unknown version' do
-      allow(chromedriver).to receive(:chrome_version).and_return('72.0.0')
-      msg = 'please set `Webdrivers::Chromedriver.version = <desired driver version>` to an known chromedriver '\
-'version: https://chromedriver.storage.googleapis.com/index.html'
-      expect { chromedriver.update }.to raise_exception(StandardError, msg)
-    end
-  end
-
-  # Workaround for Google Chrome when using Jruby on Windows.
-  # @see https://github.com/titusfortner/webdrivers/issues/41
-  if RUBY_PLATFORM == 'java' && Selenium::WebDriver::Platform.windows?
-    context 'when using Jruby on Windows' do
-      it 'uses Jruby specific workaround to retrieve the Google Chrome version' do
-        chromedriver.remove
         chromedriver.update
+
+        expect(chromedriver.send(:downloaded?)).to be false
+      end
+
+      it 'does not download when offline, binary exists and is less than v70' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(chromedriver).to receive(:downloaded?).and_return(true)
+        allow(chromedriver).to receive(:current_version).and_return(Gem::Version.new(69))
+
+        chromedriver.update
+
+        expect(File.exist?(chromedriver.binary)).to be false
+      end
+
+      it 'does not download when offline, binary exists and matches major browser version' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(chromedriver).to receive(:downloaded?).and_return(true)
+        allow(chromedriver).to receive(:chrome_version).and_return(Gem::Version.new('73.0.3683.68'))
+        allow(chromedriver).to receive(:current_version).and_return(Gem::Version.new('73.0.3683.20'))
+
+        chromedriver.update
+
+        expect(File.exist?(chromedriver.binary)).to be false
+      end
+
+      it 'raises ConnectionError when offline, and binary does not match major browser version' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(chromedriver).to receive(:downloaded?).and_return(true)
+        allow(chromedriver).to receive(:chrome_version).and_return(Gem::Version.new('73.0.3683.68'))
+        allow(chromedriver).to receive(:current_version).and_return(Gem::Version.new('72.0.0.0'))
+
+        msg = %r{Can not reach https://chromedriver.storage.googleapis.com}
+        expect { chromedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+      end
+
+      it 'raises ConnectionError when offline, and no binary exists' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(chromedriver).to receive(:downloaded?).and_return(false)
+
+        msg = %r{Can not reach https://chromedriver.storage.googleapis.com}
+        expect { chromedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+      end
+    end
+
+    context 'when correct binary is found' do
+      before { allow(chromedriver).to receive(:correct_binary?).and_return(true) }
+
+      it 'does not download' do
+        chromedriver.update
+
+        expect(chromedriver.current_version).to be_nil
+      end
+
+      it 'does not raise exception if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        chromedriver.update
+
+        expect(chromedriver.current_version).to be_nil
+      end
+    end
+
+    context 'when correct binary is not found' do
+      before { allow(chromedriver).to receive(:correct_binary?).and_return(false) }
+
+      it 'downloads binary' do
+        chromedriver.update
+
         expect(chromedriver.current_version).not_to be_nil
+      end
+
+      it 'raises ConnectionError if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        msg = %r{Can not reach https://chromedriver.storage.googleapis.com/}
+        expect { chromedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
       end
     end
   end
 
-  context 'when offline' do
-    before do
-      chromedriver.instance_variable_set('@latest_version', nil)
-      allow(chromedriver).to receive(:site_available?).and_return(false)
+  describe '#current_version' do
+    it 'returns nil if binary does not exist on the system' do
+      allow(chromedriver).to receive(:binary).and_return('')
+
+      expect(chromedriver.current_version).to be_nil
     end
 
-    it 'raises exception finding latest version' do
-      expect { chromedriver.latest_version }.to raise_error(StandardError, 'Can not reach site')
-    end
+    it 'returns a Gem::Version instance if binary is on the system' do
+      allow(chromedriver).to receive(:downloaded?).and_return(true)
+      allow(chromedriver).to receive(:system_call).and_return '71.0.3578.137'
 
-    it 'raises exception downloading' do
-      expect { chromedriver.download }.to raise_error(StandardError, 'Can not reach site')
-    end
-  end
-
-  it 'allows setting of install directory' do
-    begin
-      install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
-      Webdrivers.install_dir = install_dir
-      expect(chromedriver.install_dir).to eq install_dir
-    ensure
-      Webdrivers.install_dir = nil
+      expect(chromedriver.current_version).to eq Gem::Version.new('71.0.3578.137')
     end
   end
 
-  it 'returns full location of binary' do
-    install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers'))
-    expect(chromedriver.binary).to match %r{#{install_dir}/chromedriver}
+  describe '#latest_version' do
+    it 'returns 2.41 if the browser version is less than 70' do
+      allow(chromedriver).to receive(:chrome_version).and_return('69.0.0')
+
+      expect(chromedriver.latest_version).to eq(Gem::Version.new('2.41'))
+    end
+
+    it 'returns the correct point release for a production version greater than 70' do
+      allow(chromedriver).to receive(:chrome_version).and_return '71.0.3578.9999'
+
+      expect(chromedriver.latest_version).to eq Gem::Version.new('71.0.3578.137')
+    end
+
+    it 'raises VersionError for beta version' do
+      allow(chromedriver).to receive(:chrome_version).and_return('100.0.0')
+      msg = 'you appear to be using a non-production version of Chrome; please set '\
+'`Webdrivers::Chromedriver.version = <desired driver version>` to an known chromedriver version: '\
+'https://chromedriver.storage.googleapis.com/index.html'
+
+      expect { chromedriver.latest_version }.to raise_exception(Webdrivers::VersionError, msg)
+    end
+
+    it 'raises VersionError for unknown version' do
+      allow(chromedriver).to receive(:chrome_version).and_return('72.0.9999.0000')
+      msg = 'please set `Webdrivers::Chromedriver.version = <desired driver version>` to an known chromedriver '\
+'version: https://chromedriver.storage.googleapis.com/index.html'
+
+      expect { chromedriver.latest_version }.to raise_exception(Webdrivers::VersionError, msg)
+    end
+
+    it 'raises ConnectionError when offline' do
+      allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+      msg = %r{^Can not reach https://chromedriver.storage.googleapis.com}
+      expect { chromedriver.latest_version }.to raise_error(Webdrivers::ConnectionError, msg)
+    end
+  end
+
+  describe '#desired_version' do
+    it 'returns #latest_version if version is not specified' do
+      allow(chromedriver).to receive(:latest_version)
+
+      chromedriver.desired_version
+      expect(chromedriver).to have_received(:latest_version)
+    end
+
+    it 'returns the version specified as a Float' do
+      chromedriver.version = 73.0
+
+      expect(chromedriver.desired_version).to eq Gem::Version.new('73.0')
+    end
+
+    it 'returns the version specified as a String' do
+      chromedriver.version = '73.0'
+
+      expect(chromedriver.desired_version).to eq Gem::Version.new('73.0')
+    end
+  end
+
+  describe '#remove' do
+    it 'removes existing chromedriver' do
+      chromedriver.update
+
+      chromedriver.remove
+      expect(chromedriver.current_version).to be_nil
+    end
+
+    it 'does not raise exception if no chromedriver found' do
+      chromedriver.update
+
+      expect { chromedriver.remove }.not_to raise_error
+    end
+  end
+
+  describe '#install_dir' do
+    it 'uses ~/.webdrivers as default value' do
+      expect(chromedriver.install_dir).to include('.webdriver')
+    end
+
+    it 'uses provided value' do
+      begin
+        install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
+        Webdrivers.install_dir = install_dir
+
+        expect(chromedriver.install_dir).to eq install_dir
+      ensure
+        Webdrivers.install_dir = nil
+      end
+    end
+  end
+
+  describe '#binary' do
+    it 'returns full location of binary' do
+      expect(chromedriver.binary).to eq("#{File.join(ENV['HOME'])}/.webdrivers/chromedriver")
+    end
   end
 end

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -98,6 +98,7 @@ describe Webdrivers::Chromedriver do
 
     it 'makes a network call if cached driver does not match the browser' do
       Webdrivers::System.cache_version('chromedriver', '71.0.3578.137')
+      allow(Webdrivers).to receive(:cache_time).and_retur(3600)
       allow(chromedriver).to receive(:chrome_version).and_return(Gem::Version.new('73.0.3683.68'))
       allow(Webdrivers::Network).to receive(:get).and_return('73.0.3683.68')
       allow(Webdrivers::System).to receive(:download)
@@ -170,6 +171,7 @@ describe Webdrivers::Chromedriver do
     end
 
     it 'does not make network call if cache is valid' do
+      allow(Webdrivers).to receive(:cache_time).and_return(3600)
       Webdrivers::System.cache_version('chromedriver', '71.0.3578.137')
       allow(Webdrivers::Network).to receive(:get)
 
@@ -179,7 +181,6 @@ describe Webdrivers::Chromedriver do
     end
 
     it 'makes a network call if cache is expired' do
-      allow(Webdrivers).to receive(:cache_time).and_return(0)
       Webdrivers::System.cache_version('chromedriver', '71.0.3578.137')
       allow(Webdrivers::Network).to receive(:get).and_return('73.0.3683.68')
       allow(Webdrivers::System).to receive(:valid_cache?)

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -7,7 +7,7 @@ describe Webdrivers::Chromedriver do
 
   before do
     chromedriver.remove
-    chromedriver.version = nil
+    chromedriver.required_version = nil
   end
 
   describe '#update' do
@@ -28,7 +28,7 @@ describe Webdrivers::Chromedriver do
 
         chromedriver.update
 
-        expect(File.exist?(chromedriver.binary)).to be false
+        expect(File.exist?(chromedriver.driver_path)).to be false
       end
 
       it 'does not download when offline, binary exists and matches major browser version' do
@@ -39,7 +39,7 @@ describe Webdrivers::Chromedriver do
 
         chromedriver.update
 
-        expect(File.exist?(chromedriver.binary)).to be false
+        expect(File.exist?(chromedriver.driver_path)).to be false
       end
 
       it 'raises ConnectionError when offline, and binary does not match major browser version' do
@@ -99,7 +99,7 @@ describe Webdrivers::Chromedriver do
 
   describe '#current_version' do
     it 'returns nil if binary does not exist on the system' do
-      allow(chromedriver).to receive(:binary).and_return('')
+      allow(chromedriver).to receive(:driver_path).and_return('')
 
       expect(chromedriver.current_version).to be_nil
     end
@@ -128,7 +128,7 @@ describe Webdrivers::Chromedriver do
     it 'raises VersionError for beta version' do
       allow(chromedriver).to receive(:chrome_version).and_return('100.0.0')
       msg = 'you appear to be using a non-production version of Chrome; please set '\
-'`Webdrivers::Chromedriver.version = <desired driver version>` to an known chromedriver version: '\
+'`Webdrivers::Chromedriver.required_version = <desired driver version>` to an known chromedriver version: '\
 'https://chromedriver.storage.googleapis.com/index.html'
 
       expect { chromedriver.latest_version }.to raise_exception(Webdrivers::VersionError, msg)
@@ -136,8 +136,8 @@ describe Webdrivers::Chromedriver do
 
     it 'raises VersionError for unknown version' do
       allow(chromedriver).to receive(:chrome_version).and_return('72.0.9999.0000')
-      msg = 'please set `Webdrivers::Chromedriver.version = <desired driver version>` to an known chromedriver '\
-'version: https://chromedriver.storage.googleapis.com/index.html'
+      msg = 'please set `Webdrivers::Chromedriver.required_version = <desired driver version>` '\
+'to an known chromedriver version: https://chromedriver.storage.googleapis.com/index.html'
 
       expect { chromedriver.latest_version }.to raise_exception(Webdrivers::VersionError, msg)
     end
@@ -150,24 +150,17 @@ describe Webdrivers::Chromedriver do
     end
   end
 
-  describe '#desired_version' do
-    it 'returns #latest_version if version is not specified' do
-      allow(chromedriver).to receive(:latest_version)
-
-      chromedriver.desired_version
-      expect(chromedriver).to have_received(:latest_version)
-    end
-
+  describe '#required_version=' do
     it 'returns the version specified as a Float' do
-      chromedriver.version = 73.0
+      chromedriver.required_version = 73.0
 
-      expect(chromedriver.desired_version).to eq Gem::Version.new('73.0')
+      expect(chromedriver.required_version).to eq Gem::Version.new('73.0')
     end
 
     it 'returns the version specified as a String' do
-      chromedriver.version = '73.0'
+      chromedriver.required_version = '73.0'
 
-      expect(chromedriver.desired_version).to eq Gem::Version.new('73.0')
+      expect(chromedriver.required_version).to eq Gem::Version.new('73.0')
     end
   end
 
@@ -203,9 +196,9 @@ describe Webdrivers::Chromedriver do
     end
   end
 
-  describe '#binary' do
+  describe '#driver_path' do
     it 'returns full location of binary' do
-      expect(chromedriver.binary).to match("#{File.join(ENV['HOME'])}/.webdrivers/chromedriver")
+      expect(chromedriver.driver_path).to match("#{File.join(ENV['HOME'])}/.webdrivers/chromedriver")
     end
   end
 end

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -205,7 +205,7 @@ describe Webdrivers::Chromedriver do
 
   describe '#binary' do
     it 'returns full location of binary' do
-      expect(chromedriver.binary).to eq("#{File.join(ENV['HOME'])}/.webdrivers/chromedriver")
+      expect(chromedriver.binary).to match("#{File.join(ENV['HOME'])}/.webdrivers/chromedriver")
     end
   end
 end

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -135,6 +135,7 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
     end
 
     it 'does not make network call if cache is valid' do
+      allow(Webdrivers).to receive(:cache_time).and_return(3600)
       Webdrivers::System.cache_version('geckodriver', '0.23.0')
       allow(Webdrivers::Network).to receive(:get)
 
@@ -144,7 +145,6 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
     end
 
     it 'makes a network call if cache is expired' do
-      allow(Webdrivers).to receive(:cache_time).and_return(0)
       Webdrivers::System.cache_version('geckodriver', '0.23.0')
       url = 'https://github.com/mozilla/geckodriver/releases/tag/v0.24.0'
       allow(Webdrivers::Network).to receive(:get_url).and_return(url)

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -126,6 +126,35 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
 
       expect(geckodriver.latest_version).to eq Gem::Version.new('0.24.0')
     end
+
+    it 'creates cached file' do
+      allow(Webdrivers::Network).to receive(:get).and_return('0.24.0')
+
+      geckodriver.latest_version
+      expect(File.exist?("#{Webdrivers::System.install_dir}/geckodriver.version")).to eq true
+    end
+
+    it 'does not make network call if cache is valid' do
+      Webdrivers::System.cache_version('geckodriver', '0.23.0')
+      allow(Webdrivers::Network).to receive(:get)
+
+      expect(geckodriver.latest_version).to eq Gem::Version.new('0.23.0')
+
+      expect(Webdrivers::Network).not_to have_received(:get)
+    end
+
+    it 'makes a network call if cache is expired' do
+      allow(Webdrivers).to receive(:cache_time).and_return(0)
+      Webdrivers::System.cache_version('geckodriver', '0.23.0')
+      url = 'https://github.com/mozilla/geckodriver/releases/tag/v0.24.0'
+      allow(Webdrivers::Network).to receive(:get_url).and_return(url)
+      allow(Webdrivers::System).to receive(:valid_cache?)
+
+      expect(geckodriver.latest_version).to eq Gem::Version.new('0.24.0')
+
+      expect(Webdrivers::Network).to have_received(:get_url)
+      expect(Webdrivers::System).to have_received(:valid_cache?)
+    end
   end
 
   describe '#required_version=' do

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -169,7 +169,7 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
 
   describe '#binary' do
     it 'returns full location of binary' do
-      expect(geckodriver.binary).to eq("#{File.join(ENV['HOME'])}/.webdrivers/geckodriver")
+      expect(geckodriver.binary).to match("#{File.join(ENV['HOME'])}/.webdrivers/geckodriver")
     end
   end
 end

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -7,7 +7,7 @@ describe Webdrivers::Geckodriver do
 
   before do
     geckodriver.remove
-    geckodriver.version = nil
+    geckodriver.required_version = nil
   end
 
   describe '#update' do
@@ -27,7 +27,7 @@ describe Webdrivers::Geckodriver do
 
         geckodriver.update
 
-        expect(File.exist?(geckodriver.binary)).to be false
+        expect(File.exist?(geckodriver.driver_path)).to be false
       end
 
       it 'raises ConnectionError when offline, and no binary exists' do
@@ -76,7 +76,7 @@ describe Webdrivers::Geckodriver do
 
   describe '#current_version' do
     it 'returns nil if binary does not exist on the system' do
-      allow(geckodriver).to receive(:binary).and_return('')
+      allow(geckodriver).to receive(:driver_path).and_return('')
 
       expect(geckodriver.current_version).to be_nil
     end
@@ -114,24 +114,17 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
     end
   end
 
-  describe '#desired_version' do
-    it 'returns #latest_version if version is not specified' do
-      allow(geckodriver).to receive(:latest_version)
-
-      geckodriver.desired_version
-      expect(geckodriver).to have_received(:latest_version)
-    end
-
+  describe '#required_version=' do
     it 'returns the version specified as a Float' do
-      geckodriver.version = 0.12
+      geckodriver.required_version = 0.12
 
-      expect(geckodriver.desired_version).to eq Gem::Version.new('0.12')
+      expect(geckodriver.required_version).to eq Gem::Version.new('0.12')
     end
 
     it 'returns the version specified as a String' do
-      geckodriver.version = '0.12.1'
+      geckodriver.required_version = '0.12.1'
 
-      expect(geckodriver.desired_version).to eq Gem::Version.new('0.12.1')
+      expect(geckodriver.required_version).to eq Gem::Version.new('0.12.1')
     end
   end
 
@@ -167,9 +160,9 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
     end
   end
 
-  describe '#binary' do
+  describe '#driver_path' do
     it 'returns full location of binary' do
-      expect(geckodriver.binary).to match("#{File.join(ENV['HOME'])}/.webdrivers/geckodriver")
+      expect(geckodriver.driver_path).to match("#{File.join(ENV['HOME'])}/.webdrivers/geckodriver")
     end
   end
 end

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -72,6 +72,25 @@ describe Webdrivers::Geckodriver do
         expect { geckodriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
       end
     end
+
+    it 'finds the required version from parsed downloads page' do
+      base = 'https://github.com/mozilla/geckodriver/releases/download'
+      url = "#{base}/v0.2.0/geckodriver-v0.2.0-macos.tar.gz"
+
+      allow(Webdrivers::System).to receive(:download).with(url, geckodriver.driver_path)
+
+      geckodriver.required_version = '0.2.0'
+      geckodriver.update
+
+      expect(Webdrivers::System).to have_received(:download).with(url, geckodriver.driver_path)
+    end
+
+    it 'does something when a wrong version is supplied' do
+      geckodriver.required_version = '0.2.0'
+
+      msg = /Net::HTTPServerException: 404 "Not Found"/
+      expect { geckodriver.update }.to raise_error(StandardError, msg)
+    end
   end
 
   describe '#current_version' do
@@ -99,18 +118,13 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
   end
 
   describe '#latest_version' do
-    it 'finds the latest version from parsed hash' do
-      base = 'https://github.com/mozilla/geckodriver/releases/download'
-      hash = {Gem::Version.new('0.1.0') => "#{base}/v0.1.0/geckodriver-v0.1.0-macos.tar.gz",
-              Gem::Version.new('0.2.0') => "#{base}/v0.2.0/geckodriver-v0.2.0-macos.tar.gz",
-              Gem::Version.new('0.3.0') => "#{base}/v0.3.0/geckodriver-v0.3.0-macos.tar.gz"}
-      allow(geckodriver).to receive(:downloads).and_return(hash)
+    it 'finds the latest version directly' do
+      url = 'https://github.com/mozilla/geckodriver/releases/tag/v0.24.0'
+      allow(Webdrivers::Network).to receive(:get_url).and_return(url)
 
-      expect(geckodriver.latest_version).to eq Gem::Version.new('0.3.0')
-    end
+      geckodriver.update
 
-    it 'correctly parses the downloads page' do
-      expect(geckodriver.send(:downloads)).not_to be_empty
+      expect(geckodriver.latest_version).to eq Gem::Version.new('0.24.0')
     end
   end
 

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -92,7 +92,7 @@ testing/geckodriver in https://hg.mozilla.org/mozilla-central.
 This program is subject to the terms of the Mozilla Public License 2.0.
 You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
 
-      allow(geckodriver).to receive(:system_call).and_return return_value
+      allow(Webdrivers::System).to receive(:call).with("#{geckodriver.driver_path} --version").and_return return_value
 
       expect(geckodriver.current_version).to eq Gem::Version.new('0.24.0')
     end
@@ -145,7 +145,7 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
 
   describe '#install_dir' do
     it 'uses ~/.webdrivers as default value' do
-      expect(geckodriver.install_dir).to include('.webdriver')
+      expect(Webdrivers::System.install_dir).to include('.webdriver')
     end
 
     it 'uses provided value' do
@@ -153,7 +153,7 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
         install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
         Webdrivers.install_dir = install_dir
 
-        expect(geckodriver.install_dir).to eq install_dir
+        expect(Webdrivers::System.install_dir).to eq install_dir
       ensure
         Webdrivers.install_dir = nil
       end

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -5,37 +5,165 @@ require 'spec_helper'
 describe Webdrivers::IEdriver do
   let(:iedriver) { described_class }
 
-  it 'finds latest version' do
-    old_version = Gem::Version.new('3.12.0')
-    future_version = Gem::Version.new('4.0')
-    desired_version = iedriver.desired_version
-
-    expect(desired_version).to be > old_version
-    expect(desired_version).to be < future_version
-  end
-
-  it 'downloads iedriver' do
+  before do
     iedriver.remove
-    expect(File.exist?(iedriver.download)).to be true
+    iedriver.version = nil
   end
 
-  it 'removes iedriver' do
-    iedriver.remove
-    expect(iedriver.current_version).to be_nil
-  end
+  describe '#update' do
+    context 'when evaluating #correct_binary?' do
+      it 'does not download when latest version and current version match' do
+        allow(iedriver).to receive(:latest_version).and_return(Gem::Version.new('0.3.0'))
+        allow(iedriver).to receive(:current_version).and_return(Gem::Version.new('0.3.0'))
 
-  context 'when offline' do
-    before do
-      iedriver.instance_variable_set('@latest_version', nil)
-      allow(iedriver).to receive(:site_available?).and_return(false)
+        iedriver.update
+
+        expect(iedriver.send(:downloaded?)).to be false
+      end
+
+      it 'does not download when offline, but binary exists' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(iedriver).to receive(:downloaded?).and_return(true)
+
+        iedriver.update
+
+        expect(File.exist?(iedriver.binary)).to be false
+      end
+
+      it 'raises ConnectionError when offline, and no binary exists' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(iedriver).to receive(:downloaded?).and_return(false)
+
+        expect { iedriver.update }.to raise_error(Webdrivers::ConnectionError)
+      end
     end
 
-    it 'raises exception finding latest version' do
-      expect { iedriver.latest_version }.to raise_error(StandardError, 'Can not reach site')
+    context 'when correct binary is found' do
+      before { allow(iedriver).to receive(:correct_binary?).and_return(true) }
+
+      it 'does not download' do
+        iedriver.update
+
+        expect(iedriver.current_version).to be_nil
+      end
+
+      it 'does not raise exception if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        iedriver.update
+
+        expect(iedriver.current_version).to be_nil
+      end
     end
 
-    it 'raises exception downloading' do
-      expect { iedriver.download }.to raise_error(StandardError, 'Can not reach site')
+    context 'when correct binary is not found' do
+      before { allow(iedriver).to receive(:correct_binary?).and_return(false) }
+
+      it 'downloads binary' do
+        iedriver.update
+
+        expect(File.exist?(iedriver.binary)).to eq true
+      end
+
+      it 'raises ConnectionError if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        msg = %r{Can not reach https://selenium-release.storage.googleapis.com/}
+        expect { iedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+      end
+    end
+  end
+
+  describe '#current_version' do
+    it 'returns nil if binary does not exist on the system' do
+      allow(iedriver).to receive(:binary).and_return('')
+
+      expect(iedriver.current_version).to be_nil
+    end
+
+    it 'returns a Gem::Version instance if binary is on the system' do
+      allow(iedriver).to receive(:downloaded?).and_return(true)
+
+      return_value = 'something IEDriverServer.exe 3.5.1 something else'
+
+      allow(iedriver).to receive(:system_call).and_return return_value
+
+      expect(iedriver.current_version).to eq Gem::Version.new('3.5.1')
+    end
+  end
+
+  describe '#latest_version' do
+    it 'finds the latest version from parsed hash' do
+      base = 'https://selenium-release.storage.googleapis.com/'
+      hash = {Gem::Version.new('3.4.0') => "#{base}/3.4/IEDriverServer_Win32_3.4.0.zip",
+              Gem::Version.new('3.5.0') => "#{base}/3.5/IEDriverServer_Win32_3.5.0.zip",
+              Gem::Version.new('3.5.1') => "#{base}/3.5/IEDriverServer_Win32_3.5.1.zip"}
+      allow(iedriver).to receive(:downloads).and_return(hash)
+
+      expect(iedriver.latest_version).to eq Gem::Version.new('3.5.1')
+    end
+
+    it 'correctly parses the downloads page' do
+      expect(iedriver.send(:downloads)).not_to be_empty
+    end
+  end
+
+  describe '#desired_version' do
+    it 'returns #latest_version if version is not specified' do
+      allow(iedriver).to receive(:latest_version)
+      iedriver.desired_version
+
+      expect(iedriver).to have_received(:latest_version)
+    end
+
+    it 'returns the version specified as a Float' do
+      iedriver.version = 0.12
+
+      expect(iedriver.desired_version).to eq Gem::Version.new('0.12')
+    end
+
+    it 'returns the version specified as a String' do
+      iedriver.version = '0.12.1'
+
+      expect(iedriver.desired_version).to eq Gem::Version.new('0.12.1')
+    end
+  end
+
+  describe '#remove' do
+    it 'removes existing iedriver' do
+      iedriver.update
+
+      iedriver.remove
+      expect(iedriver.current_version).to be_nil
+    end
+
+    it 'does not raise exception if no iedriver found' do
+      iedriver.update
+
+      expect { iedriver.remove }.not_to raise_error
+    end
+  end
+
+  describe '#install_dir' do
+    it 'uses ~/.webdrivers as default value' do
+      expect(iedriver.install_dir).to include('.webdriver')
+    end
+
+    it 'uses provided value' do
+      begin
+        install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
+        Webdrivers.install_dir = install_dir
+
+        expect(iedriver.install_dir).to eq install_dir
+      ensure
+        Webdrivers.install_dir = nil
+      end
+    end
+  end
+
+  describe '#binary' do
+    it 'returns full location of binary' do
+      expect(iedriver.binary).to eq("#{File.join(ENV['HOME'])}/.webdrivers/IEDriverServer.exe")
     end
   end
 end

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -7,7 +7,7 @@ describe Webdrivers::IEdriver do
 
   before do
     iedriver.remove
-    iedriver.version = nil
+    iedriver.required_version = nil
   end
 
   describe '#update' do
@@ -27,7 +27,7 @@ describe Webdrivers::IEdriver do
 
         iedriver.update
 
-        expect(File.exist?(iedriver.binary)).to be false
+        expect(File.exist?(iedriver.driver_path)).to be false
       end
 
       it 'raises ConnectionError when offline, and no binary exists' do
@@ -62,7 +62,7 @@ describe Webdrivers::IEdriver do
       it 'downloads binary' do
         iedriver.update
 
-        expect(File.exist?(iedriver.binary)).to eq true
+        expect(File.exist?(iedriver.driver_path)).to eq true
       end
 
       it 'raises ConnectionError if offline' do
@@ -76,7 +76,7 @@ describe Webdrivers::IEdriver do
 
   describe '#current_version' do
     it 'returns nil if binary does not exist on the system' do
-      allow(iedriver).to receive(:binary).and_return('')
+      allow(iedriver).to receive(:driver_path).and_return('')
 
       expect(iedriver.current_version).to be_nil
     end
@@ -108,24 +108,17 @@ describe Webdrivers::IEdriver do
     end
   end
 
-  describe '#desired_version' do
-    it 'returns #latest_version if version is not specified' do
-      allow(iedriver).to receive(:latest_version)
-      iedriver.desired_version
-
-      expect(iedriver).to have_received(:latest_version)
-    end
-
+  describe '#required_version=' do
     it 'returns the version specified as a Float' do
-      iedriver.version = 0.12
+      iedriver.required_version = 0.12
 
-      expect(iedriver.desired_version).to eq Gem::Version.new('0.12')
+      expect(iedriver.required_version).to eq Gem::Version.new('0.12')
     end
 
     it 'returns the version specified as a String' do
-      iedriver.version = '0.12.1'
+      iedriver.required_version = '0.12.1'
 
-      expect(iedriver.desired_version).to eq Gem::Version.new('0.12.1')
+      expect(iedriver.required_version).to eq Gem::Version.new('0.12.1')
     end
   end
 
@@ -161,9 +154,9 @@ describe Webdrivers::IEdriver do
     end
   end
 
-  describe '#binary' do
+  describe '#driver_path' do
     it 'returns full location of binary' do
-      expect(iedriver.binary).to eq("#{File.join(ENV['HOME'])}/.webdrivers/IEDriverServer.exe")
+      expect(iedriver.driver_path).to eq("#{File.join(ENV['HOME'])}/.webdrivers/IEDriverServer.exe")
     end
   end
 end

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -115,6 +115,7 @@ describe Webdrivers::IEdriver do
     end
 
     it 'does not make network call if cache is valid' do
+      allow(Webdrivers).to receive(:cache_time).and_return(3600)
       Webdrivers::System.cache_version('IEDriverServer', '3.4.0')
       allow(Webdrivers::Network).to receive(:get)
 
@@ -124,7 +125,6 @@ describe Webdrivers::IEdriver do
     end
 
     it 'makes a network call if cache is expired' do
-      allow(Webdrivers).to receive(:cache_time).and_return(0)
       Webdrivers::System.cache_version('IEDriverServer', '3.4.0')
       base = 'https://selenium-release.storage.googleapis.com/'
       hash = {Gem::Version.new('3.4.0') => "#{base}/3.4/IEDriverServer_Win32_3.4.0.zip",

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -86,7 +86,7 @@ describe Webdrivers::IEdriver do
 
       return_value = 'something IEDriverServer.exe 3.5.1 something else'
 
-      allow(iedriver).to receive(:system_call).and_return return_value
+      allow(Webdrivers::System).to receive(:call).with("#{iedriver.driver_path} --version").and_return return_value
 
       expect(iedriver.current_version).to eq Gem::Version.new('3.5.1')
     end
@@ -139,7 +139,7 @@ describe Webdrivers::IEdriver do
 
   describe '#install_dir' do
     it 'uses ~/.webdrivers as default value' do
-      expect(iedriver.install_dir).to include('.webdriver')
+      expect(Webdrivers::System.install_dir).to include('.webdriver')
     end
 
     it 'uses provided value' do
@@ -147,7 +147,7 @@ describe Webdrivers::IEdriver do
         install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
         Webdrivers.install_dir = install_dir
 
-        expect(iedriver.install_dir).to eq install_dir
+        expect(Webdrivers::System.install_dir).to eq install_dir
       ensure
         Webdrivers.install_dir = nil
       end

--- a/spec/webdrivers/ms_webdriver_spec.rb
+++ b/spec/webdrivers/ms_webdriver_spec.rb
@@ -6,14 +6,15 @@ describe Webdrivers::MSWebdriver do
   let(:mswebdriver) { described_class }
 
   before do
-    allow(mswebdriver).to receive(:system_call).and_return('41.16299.248.0')
+    allow(Webdrivers::System).to receive(:call).and_return '41.16299.248.0'
+
     mswebdriver.remove
     mswebdriver.required_version = nil
   end
 
   describe '#install_dir' do
     it 'uses ~/.webdrivers as default value' do
-      expect(mswebdriver.install_dir).to include('.webdriver')
+      expect(Webdrivers::System.install_dir).to include('.webdriver')
     end
 
     it 'raises ConnectionError if offline and no binary is found' do
@@ -107,7 +108,7 @@ describe Webdrivers::MSWebdriver do
         install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
         Webdrivers.install_dir = install_dir
 
-        expect(mswebdriver.install_dir).to eq install_dir
+        expect(Webdrivers::System.install_dir).to eq install_dir
       ensure
         Webdrivers.install_dir = nil
       end

--- a/spec/webdrivers/ms_webdriver_spec.rb
+++ b/spec/webdrivers/ms_webdriver_spec.rb
@@ -7,7 +7,7 @@ describe Webdrivers::MSWebdriver do
 
   it 'downloads mswebdriver' do
     mswebdriver.remove
-    allow(mswebdriver).to receive(:desired_version).and_return(mswebdriver.latest_version)
+    allow(mswebdriver).to receive(:windows_version).and_return(mswebdriver.latest_version)
     expect(File.exist?(mswebdriver.download)).to be true
   end
 
@@ -17,10 +17,11 @@ describe Webdrivers::MSWebdriver do
   end
 
   context 'when offline' do
-    before { allow(mswebdriver).to receive(:site_available?).and_return(false) }
+    before { allow(Net::HTTP).to receive(:get_response).and_raise(SocketError) }
 
     it 'raises exception downloading' do
-      expect { mswebdriver.download }.to raise_error(StandardError, 'Can not reach site')
+      msg = 'Can not reach https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
+      expect { mswebdriver.download }.to raise_error(Webdrivers::ConnectionError, msg)
     end
   end
 end

--- a/spec/webdrivers/ms_webdriver_spec.rb
+++ b/spec/webdrivers/ms_webdriver_spec.rb
@@ -8,7 +8,7 @@ describe Webdrivers::MSWebdriver do
   before do
     allow(mswebdriver).to receive(:system_call).and_return('41.16299.248.0')
     mswebdriver.remove
-    mswebdriver.version = nil
+    mswebdriver.required_version = nil
   end
 
   describe '#install_dir' do
@@ -55,24 +55,17 @@ describe Webdrivers::MSWebdriver do
     end
   end
 
-  describe '#desired_version' do
-    it 'returns #latest_version if version is not specified' do
-      allow(mswebdriver).to receive(:latest_version)
-      mswebdriver.desired_version
-
-      expect(mswebdriver).to have_received(:latest_version)
-    end
-
+  describe '#required_version' do
     it 'returns the version specified as a Float' do
-      mswebdriver.version = 0.12
+      mswebdriver.required_version = 0.12
 
-      expect(mswebdriver.desired_version).to eq Gem::Version.new('0.12')
+      expect(mswebdriver.required_version).to eq Gem::Version.new('0.12')
     end
 
     it 'returns the version specified as a String' do
-      mswebdriver.version = '0.12.1'
+      mswebdriver.required_version = '0.12.1'
 
-      expect(mswebdriver.desired_version).to eq Gem::Version.new('0.12.1')
+      expect(mswebdriver.required_version).to eq Gem::Version.new('0.12.1')
     end
   end
 
@@ -81,7 +74,7 @@ describe Webdrivers::MSWebdriver do
       mswebdriver.update
 
       mswebdriver.remove
-      expect(File.exist?(mswebdriver.binary)).to eq false
+      expect(File.exist?(mswebdriver.driver_path)).to eq false
     end
 
     it 'does not raise exception if no mswebdriver found' do
@@ -97,12 +90,12 @@ describe Webdrivers::MSWebdriver do
       mswebdriver.update
 
       expect(mswebdriver).to have_received(:downloads)
-      expect(File.exist?(mswebdriver.binary)).to eq true
+      expect(File.exist?(mswebdriver.driver_path)).to eq true
     end
 
     it 'does not download binary if one exists and offline' do
       allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
-      allow(File).to receive(:exist?).with(mswebdriver.binary).and_return(true)
+      allow(File).to receive(:exist?).with(mswebdriver.driver_path).and_return(true)
       allow(mswebdriver).to receive(:download_url)
 
       mswebdriver.update
@@ -121,9 +114,9 @@ describe Webdrivers::MSWebdriver do
     end
   end
 
-  describe '#binary' do
+  describe '#driver_path' do
     it 'returns full location of binary' do
-      expect(mswebdriver.binary).to eq("#{File.join(ENV['HOME'])}/.webdrivers/MicrosoftWebDriver.exe")
+      expect(mswebdriver.driver_path).to eq("#{File.join(ENV['HOME'])}/.webdrivers/MicrosoftWebDriver.exe")
     end
   end
 end

--- a/spec/webdrivers/ms_webdriver_spec.rb
+++ b/spec/webdrivers/ms_webdriver_spec.rb
@@ -5,23 +5,125 @@ require 'spec_helper'
 describe Webdrivers::MSWebdriver do
   let(:mswebdriver) { described_class }
 
-  it 'downloads mswebdriver' do
+  before do
+    allow(mswebdriver).to receive(:system_call).and_return('41.16299.248.0')
     mswebdriver.remove
-    allow(mswebdriver).to receive(:windows_version).and_return(mswebdriver.latest_version)
-    expect(File.exist?(mswebdriver.download)).to be true
+    mswebdriver.version = nil
   end
 
-  it 'removes mswebdriver' do
-    mswebdriver.remove
-    expect(File.exist?(mswebdriver.send(:binary))).to be false
+  describe '#install_dir' do
+    it 'uses ~/.webdrivers as default value' do
+      expect(mswebdriver.install_dir).to include('.webdriver')
+    end
+
+    it 'raises ConnectionError if offline and no binary is found' do
+      allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+      msg = %r{Can not reach https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/}
+      expect { mswebdriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+    end
   end
 
-  context 'when offline' do
-    before { allow(Net::HTTP).to receive(:get_response).and_raise(SocketError) }
+  describe '#current_version' do
+    it 'raises a NotImplementedError' do
+      msg = 'Unable to programatically determine the version of most MicrosoftWebDriver.exe'
+      expect { mswebdriver.current_version }.to raise_error(NotImplementedError, msg)
+    end
+  end
 
-    it 'raises exception downloading' do
-      msg = 'Can not reach https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
-      expect { mswebdriver.download }.to raise_error(Webdrivers::ConnectionError, msg)
+  describe '#latest_version' do
+    it 'finds the latest version from parsed hash' do
+      base = 'https://download.microsoft.com/download/'
+      file_name = 'MicrosoftWebDriver.exe'
+
+      hash = {Gem::Version.new('17134') => "#{base}F/8/A/F8AF50AB-3C3A-4BC4-8773-DC27B32988DD/#{file_name}",
+              Gem::Version.new('16299') => "#{base}D/4/1/D417998A-58EE-4EFE-A7CC-39EF9E020768/#{file_name}",
+              Gem::Version.new('15063') => "#{base}3/4/2/342316D7-EBE0-4F10-ABA2-AE8E0CDF36DD/#{file_name}"}
+      allow(mswebdriver).to receive(:downloads).and_return(hash)
+
+      expect(mswebdriver.latest_version).to eq Gem::Version.new('16299')
+    end
+
+    it 'raises a VersionError for Microsoft Edge version 18' do
+      allow(mswebdriver).to receive(:windows_version).and_return(Gem::Version.new(45.0))
+
+      expect { mswebdriver.latest_version }.to raise_error(Webdrivers::VersionError)
+    end
+
+    it 'correctly parses the downloads page' do
+      expect(mswebdriver.send(:downloads)).not_to be_empty
+    end
+  end
+
+  describe '#desired_version' do
+    it 'returns #latest_version if version is not specified' do
+      allow(mswebdriver).to receive(:latest_version)
+      mswebdriver.desired_version
+
+      expect(mswebdriver).to have_received(:latest_version)
+    end
+
+    it 'returns the version specified as a Float' do
+      mswebdriver.version = 0.12
+
+      expect(mswebdriver.desired_version).to eq Gem::Version.new('0.12')
+    end
+
+    it 'returns the version specified as a String' do
+      mswebdriver.version = '0.12.1'
+
+      expect(mswebdriver.desired_version).to eq Gem::Version.new('0.12.1')
+    end
+  end
+
+  describe '#remove' do
+    it 'removes existing mswebdriver' do
+      mswebdriver.update
+
+      mswebdriver.remove
+      expect(File.exist?(mswebdriver.binary)).to eq false
+    end
+
+    it 'does not raise exception if no mswebdriver found' do
+      mswebdriver.update
+
+      expect { mswebdriver.remove }.not_to raise_error
+    end
+  end
+
+  describe '#update' do
+    it 'downloads binary from the list if it does not exist' do
+      allow(mswebdriver).to receive(:downloads).and_return(mswebdriver.send(:downloads))
+      mswebdriver.update
+
+      expect(mswebdriver).to have_received(:downloads)
+      expect(File.exist?(mswebdriver.binary)).to eq true
+    end
+
+    it 'does not download binary if one exists and offline' do
+      allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+      allow(File).to receive(:exist?).with(mswebdriver.binary).and_return(true)
+      allow(mswebdriver).to receive(:download_url)
+
+      mswebdriver.update
+      expect(mswebdriver).not_to have_received(:download_url)
+    end
+
+    it 'uses provided value' do
+      begin
+        install_dir = File.expand_path(File.join(ENV['HOME'], '.webdrivers2'))
+        Webdrivers.install_dir = install_dir
+
+        expect(mswebdriver.install_dir).to eq install_dir
+      ensure
+        Webdrivers.install_dir = nil
+      end
+    end
+  end
+
+  describe '#binary' do
+    it 'returns full location of binary' do
+      expect(mswebdriver.binary).to eq("#{File.join(ENV['HOME'])}/.webdrivers/MicrosoftWebDriver.exe")
     end
   end
 end

--- a/spec/webdrivers_proxy_support_spec.rb
+++ b/spec/webdrivers_proxy_support_spec.rb
@@ -4,7 +4,7 @@ require 'spec_helper'
 
 class FakeDriver < Webdrivers::Common
   def self.http_object
-    http
+    Webdrivers::Network.http
   end
 end
 

--- a/spec/webdrivers_proxy_support_spec.rb
+++ b/spec/webdrivers_proxy_support_spec.rb
@@ -48,6 +48,6 @@ describe Webdrivers do
   it 'raises an exception when net_http_ssl_fix is called.' do
     err = 'Webdrivers.net_http_ssl_fix is no longer available.' \
       ' Please see https://github.com/titusfortner/webdrivers#ssl_connect-errors.'
-    expect { described_class.net_http_ssl_fix }.to raise_error(Webdrivers::ConnectionError, err)
+    expect { described_class.net_http_ssl_fix }.to raise_error(StandardError, err)
   end
 end

--- a/spec/webdrivers_proxy_support_spec.rb
+++ b/spec/webdrivers_proxy_support_spec.rb
@@ -48,6 +48,6 @@ describe Webdrivers do
   it 'raises an exception when net_http_ssl_fix is called.' do
     err = 'Webdrivers.net_http_ssl_fix is no longer available.' \
       ' Please see https://github.com/titusfortner/webdrivers#ssl_connect-errors.'
-    expect { described_class.net_http_ssl_fix }.to raise_error(StandardError, err)
+    expect { described_class.net_http_ssl_fix }.to raise_error(Webdrivers::ConnectionError, err)
   end
 end

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -4,7 +4,7 @@ $LOAD_PATH.push File.expand_path('../lib', __dir__)
 
 Gem::Specification.new do |s|
   s.name        = 'webdrivers'
-  s.version     = '3.8.1'
+  s.version     = '3.9.0'
   s.authors     = ['Titus Fortner', 'Lakshya Kapoor']
   s.email       = %w[titusfortner@gmail.com kapoorlakshya@gmail.com]
   s.homepage    = 'https://github.com/titusfortner/webdrivers'


### PR DESCRIPTION
Ok, this is everything I think we need as a final 3.x release.
This might be a pain to review, but I tried to make each commit obvious and straightforward.

This is all dependent on the refactoring in #86, #90 & #91 
Caching addresses #29 & #77 
Direct downloading of geckodriver addresses #30 

I've got cache time defaulting to zero, with the idea of making it default for 4.x. Or should we set a value for 3.9?

I'm thinking we release this and then for 4.0 we:
1. Add the documentation
2. Create the Rake Tasks
3. Remove the deprecations
4. Change default cache_time to 24 hours