### PR TITLE
Add default rake task and improve RSpec config

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,3 +7,5 @@ require 'rubocop/rake_task'
 RuboCop::RakeTask.new
 
 RSpec::Core::RakeTask.new(:spec)
+
+task default: %i[rubocop spec]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,4 +9,10 @@ require 'webdrivers'
 RSpec.configure do |config|
   config.filter_run_including focus: true unless ENV['CI']
   config.run_all_when_everything_filtered = true
+  config.expect_with :rspec do |expectations|
+    expectations.syntax = :expect
+  end
+  config.mock_with :rspec do |mocks|
+    mocks.verify_partial_doubles = true
+  end
 end


### PR DESCRIPTION
First commit adds a default rake task that runs rubocop and spec.
Second turns on partial double verification to ensure mocking objects only mock valid methods with valid signature.