### PR TITLE
Ruby 2.6 deprecates Net::HTTPServerException in favor of the more correctly named Net::HTTPClientException

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,6 +7,8 @@ Layout/EndOfLine:
 
 Metrics/LineLength:
   Max: 120
+  IgnoredPatterns:
+    - '\s+# rubocop:disable'
 
 Metrics/MethodLength:
   Enabled: false

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -38,7 +38,7 @@ module Webdrivers
         release_file = "LATEST_RELEASE_#{version}"
         begin
           normalize_version(get(URI.join(base_url, release_file)))
-        rescue Net::HTTPServerException
+        rescue (Net::HTTPClientException rescue Net::HTTPServerException) # rubocop:disable Style/RescueModifier,Naming/RescuedExceptionsVariableName
           latest_release = normalize_version(get(URI.join(base_url, 'LATEST_RELEASE')))
           Webdrivers.logger.debug "Unable to find a driver for: #{version}"
 


### PR DESCRIPTION
…