### PR TITLE
remove support for Microsoft WebDriver for Edge browser

### DIFF
--- a/lib/webdrivers/mswebdriver.rb
+++ b/lib/webdrivers/mswebdriver.rb
@@ -3,72 +3,30 @@
 require 'webdrivers/common'
 
 module Webdrivers
-  class MSWebdriver < Common
+  class MSWebdriver
     class << self
-      def windows_version
-        Webdrivers.logger.debug 'Checking current version'
-
-        # current_version() from other webdrivers returns the version from the webdriver EXE.
-        # Unfortunately, MicrosoftWebDriver.exe does not have an option to get the version.
-        # To work around it we query the currently installed version of Microsoft Edge instead
-        # and compare it to the list of available downloads.
-        version = `powershell (Get-AppxPackage -Name Microsoft.MicrosoftEdge).Version`
-        raise 'Failed to check Microsoft Edge version.' if version.empty? # Package name changed?
-
-        Webdrivers.logger.debug "Current version of Microsoft Edge is #{version.chomp!}"
-
-        build = version.split('.')[1] # "41.16299.248.0" => "16299"
-        Webdrivers.logger.debug "Expecting MicrosoftWebDriver.exe version #{build}"
-        build.to_i
-      end
-
-      # Webdriver binaries for Microsoft Edge are not backwards compatible.
-      # For this reason, instead of downloading the latest binary we download the correct one for the
-      # currently installed browser version.
-      alias version windows_version
-
-      def version=(*)
-        raise 'Version can not be set for MSWebdriver because it is dependent on the version of Edge'
-      end
-
-      private
-
-      def file_name
-        'MicrosoftWebDriver.exe'
-      end
-
-      def downloads
-        array = Nokogiri::HTML(get(base_url)).xpath("//li[@class='driver-download']/a")
-        array.each_with_object({}) do |link, hash|
-          next if link.text == 'Insiders'
-
-          key = normalize_version link.text.scan(/\d+/).first.to_i
-          hash[key] = link['href']
-        end
-      end
-
-      def base_url
-        'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
-      end
-
-      # Assume we have the latest if file exists since MicrosoftWebdriver.exe does not have an
-      # argument to check the current version.
-      def correct_binary?
-        File.exist?(binary)
-      end
+      attr_accessor :ignore
     end
   end
 end
 
-if ::Selenium::WebDriver::Service.respond_to? :driver_path=
-  ::Selenium::WebDriver::Edge::Service.driver_path = proc { ::Webdrivers::MSWebdriver.update }
-else
-  # v3.141.0 and lower
-  module Selenium
-    module WebDriver
-      module Edge
-        def self.driver_path
-          @driver_path ||= Webdrivers::MSWebdriver.update
+module Selenium
+  module WebDriver
+    module Edge
+      class << self
+        alias se_driver_path driver_path
+
+        def driver_path
+          unless Webdrivers::MSWebdriver.ignore
+            Webdrivers.logger.warn 'Microsoft WebDriver for the Edge browser is no longer supported by Webdrivers gem;'\
+          ' Due to changes in Edge implementation, the correct version can no longer be accurately provided. '\
+          'Download driver, and specify the location with `Selenium::WebDriver::Edge.driver_path = "/driver/path"`, '\
+          'or place it in PATH Environment Variable. '\
+          'Download directions here: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/#downloads'\
+          'To remove this warning in Webdrivers 3.x, set `Webdrivers.MSWebdriver.ignore`'
+          end
+
+          se_driver_path
         end
       end
     end

--- a/spec/webdrivers/ms_webdriver_spec.rb
+++ b/spec/webdrivers/ms_webdriver_spec.rb
@@ -5,22 +5,30 @@ require 'spec_helper'
 describe Webdrivers::MSWebdriver do
   let(:mswebdriver) { described_class }
 
-  it 'downloads mswebdriver' do
-    mswebdriver.remove
-    allow(mswebdriver).to receive(:desired_version).and_return(mswebdriver.latest_version)
-    expect(File.exist?(mswebdriver.download)).to be true
+  it 'gives deprecation for using it' do
+    skip if Selenium::WebDriver::VERSION == '3.142.0'
+
+    service = instance_double(Selenium::WebDriver::Service, host: '', start: nil, uri: '')
+    bridge = instance_double(Selenium::WebDriver::Remote::Bridge, create_session: nil, session_id: '')
+
+    allow(Selenium::WebDriver::Service).to receive(:new).and_return(service)
+    allow(Selenium::WebDriver::Remote::Bridge).to receive(:new).and_return(bridge)
+    allow(Selenium::WebDriver::Remote::W3C::Bridge).to receive(:new)
+
+    msg = /WARN Webdrivers Microsoft WebDriver for the Edge browser is no longer supported by Webdrivers gem/
+    expect { Selenium::WebDriver.for :edge }.to output(msg).to_stdout_from_any_process
   end
 
-  it 'removes mswebdriver' do
-    mswebdriver.remove
-    expect(File.exist?(mswebdriver.send(:binary))).to be false
-  end
+  it 'does not give deprecation when set to ignore' do
+    described_class.ignore = true
 
-  context 'when offline' do
-    before { allow(mswebdriver).to receive(:site_available?).and_return(false) }
+    service = instance_double(Selenium::WebDriver::Service, host: '', start: nil, uri: '')
+    bridge = instance_double(Selenium::WebDriver::Remote::Bridge, create_session: nil, session_id: '')
 
-    it 'raises exception downloading' do
-      expect { mswebdriver.download }.to raise_error(StandardError, 'Can not reach site')
-    end
+    allow(Selenium::WebDriver::Service).to receive(:new).and_return(service)
+    allow(Selenium::WebDriver::Remote::Bridge).to receive(:new).and_return(bridge)
+    allow(Selenium::WebDriver::Remote::W3C::Bridge).to receive(:new)
+
+    expect { Selenium::WebDriver.for :edge }.not_to output.to_stdout_from_any_process
   end
 end

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -27,5 +27,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'rubyzip', '~> 1.0'
-  s.add_runtime_dependency 'selenium-webdriver', '~> 3.0'
+  s.add_runtime_dependency 'selenium-webdriver', '= 3.142.0'
 end


### PR DESCRIPTION
I think this is the correct approach for warning existing users.

Throw a warning with instructions on how to fix and how to ignore the warning.

Note that Selenium 3.142.0 broke looking at `#driver_path` so I need to get that figured out as well.