### PR TITLE
implements driver caching

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,6 @@
+AllCops:
+  TargetRubyVersion: 2.4.6
+
 require:
   - rubocop-rspec
   - rubocop-performance
@@ -21,13 +24,15 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 102
+  Max: 116
 
 Metrics/CyclomaticComplexity:
   Max: 8
 
 Metrics/AbcSize:
   Max: 16
+  Exclude:
+    - 'lib/webdrivers/chromedriver.rb'
 
 Style/Documentation:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,5 +20,5 @@ matrix:
       env: RAKE_TASK=spec
     - rvm: 2.4.6
       env: RAKE_TASK=rubocop
-    - rvm: jruby-9.2.0.0
+    - rvm: jruby-9.2.7.0
       env: RAKE_TASK=spec

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -22,7 +22,7 @@ module Webdrivers
           # Versions before 70 do not have a LATEST_RELEASE file
           return normalize_version('2.41') if release_version < normalize_version('70')
 
-          latest_applicable = latest_point_release(release_version)
+          latest_applicable = with_cache(file_name) { latest_point_release(release_version) }
 
           Webdrivers.logger.debug "Latest version available: #{latest_applicable}"
           normalize_version(latest_applicable)
@@ -73,7 +73,7 @@ module Webdrivers
                     normalize_version(required_version)
                   end
 
-        file_name = System.platform == 'win' ? 'windows32' : "#{System.platform}64"
+        file_name = System.platform == 'win' ? 'win32' : "#{System.platform}64"
         url = "#{base_url}/#{version}/chromedriver_#{file_name}.zip"
         Webdrivers.logger.debug "chromedriver URL: #{url}"
         @download_url = url

--- a/lib/webdrivers/geckodriver.rb
+++ b/lib/webdrivers/geckodriver.rb
@@ -17,7 +17,7 @@ module Webdrivers
       end
 
       def latest_version
-        @latest_version ||= Gem::Version.new(Network.get_url("#{base_url}/latest")[/[^v]*$/])
+        @latest_version ||= with_cache(file_name) { normalize_version(Network.get_url("#{base_url}/latest")[/[^v]*$/]) }
       end
 
       private

--- a/lib/webdrivers/iedriver.rb
+++ b/lib/webdrivers/iedriver.rb
@@ -17,6 +17,10 @@ module Webdrivers
         normalize_version version.match(/IEDriverServer.exe (\d\.\d+\.\d+)/)[1]
       end
 
+      def latest_version
+        @latest_version ||= with_cache(file_name) { downloads.keys.max }
+      end
+
       private
 
       def file_name

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -26,6 +26,25 @@ module Webdrivers
         Webdrivers.install_dir || File.expand_path(File.join(ENV['HOME'], '.webdrivers'))
       end
 
+      def cache_version(file_name, version)
+        FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
+
+        File.open("#{install_dir}/#{file_name.gsub('.exe', '')}.version", 'w+') do |file|
+          file.print(version)
+        end
+      end
+
+      def cached_version(file_name)
+        File.open("#{install_dir}/#{file_name.gsub('.exe', '')}.version", 'r', &:read)
+      end
+
+      def valid_cache?(file_name)
+        file = "#{install_dir}/#{file_name.gsub('.exe', '')}.version"
+        return false unless File.exist?(file)
+
+        Time.now - File.mtime(file) < Webdrivers.cache_time
+      end
+
       def download(url, target)
         FileUtils.mkdir_p(install_dir) unless File.exist?(install_dir)
 
@@ -99,7 +118,7 @@ module Webdrivers
           zip_file.each do |f|
             @top_path ||= f.name
             f_path = File.join(Dir.pwd, f.name)
-            FileUtils.rm_rf(f_path) if File.exist?(f_path)
+            delete(f_path)
             FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))
             zip_file.extract(f, f_path)
           end

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -95,6 +95,17 @@ describe Webdrivers::Chromedriver do
         expect { chromedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
       end
     end
+
+    it 'makes a network call if cached driver does not match the browser' do
+      Webdrivers::System.cache_version('chromedriver', '71.0.3578.137')
+      allow(chromedriver).to receive(:chrome_version).and_return(Gem::Version.new('73.0.3683.68'))
+      allow(Webdrivers::Network).to receive(:get).and_return('73.0.3683.68')
+      allow(Webdrivers::System).to receive(:download)
+
+      chromedriver.update
+
+      expect(Webdrivers::Network).to have_received(:get).twice
+    end
   end
 
   describe '#current_version' do
@@ -149,6 +160,34 @@ describe Webdrivers::Chromedriver do
 
       msg = %r{^Can not reach https://chromedriver.storage.googleapis.com}
       expect { chromedriver.latest_version }.to raise_error(Webdrivers::ConnectionError, msg)
+    end
+
+    it 'creates cached file' do
+      allow(Webdrivers::Network).to receive(:get).and_return('71.0.3578.137')
+
+      chromedriver.latest_version
+      expect(File.exist?("#{Webdrivers::System.install_dir}/chromedriver.version")).to eq true
+    end
+
+    it 'does not make network call if cache is valid' do
+      allow(Webdrivers).to receive(:cache_time).and_return(3600)
+      Webdrivers::System.cache_version('chromedriver', '71.0.3578.137')
+      allow(Webdrivers::Network).to receive(:get)
+
+      expect(chromedriver.latest_version).to eq Gem::Version.new('71.0.3578.137')
+
+      expect(Webdrivers::Network).not_to have_received(:get)
+    end
+
+    it 'makes a network call if cache is expired' do
+      Webdrivers::System.cache_version('chromedriver', '71.0.3578.137')
+      allow(Webdrivers::Network).to receive(:get).and_return('73.0.3683.68')
+      allow(Webdrivers::System).to receive(:valid_cache?)
+
+      expect(chromedriver.latest_version).to eq Gem::Version.new('73.0.3683.68')
+
+      expect(Webdrivers::Network).to have_received(:get)
+      expect(Webdrivers::System).to have_received(:valid_cache?)
     end
   end
 

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -107,6 +107,37 @@ describe Webdrivers::IEdriver do
     it 'correctly parses the downloads page' do
       expect(iedriver.send(:downloads)).not_to be_empty
     end
+
+    it 'creates cached file' do
+      allow(Webdrivers::Network).to receive(:get).and_return('3.4.0')
+
+      iedriver.latest_version
+      expect(File.exist?("#{Webdrivers::System.install_dir}/IEDriverServer.version")).to eq true
+    end
+
+    it 'does not make network call if cache is valid' do
+      allow(Webdrivers).to receive(:cache_time).and_return(3600)
+      Webdrivers::System.cache_version('IEDriverServer', '3.4.0')
+      allow(Webdrivers::Network).to receive(:get)
+
+      expect(iedriver.latest_version).to eq Gem::Version.new('3.4.0')
+
+      expect(Webdrivers::Network).not_to have_received(:get)
+    end
+
+    it 'makes a network call if cache is expired' do
+      Webdrivers::System.cache_version('IEDriverServer', '3.4.0')
+      base = 'https://selenium-release.storage.googleapis.com/'
+      hash = {Gem::Version.new('3.4.0') => "#{base}/3.4/IEDriverServer_Win32_3.4.0.zip",
+              Gem::Version.new('3.5.0') => "#{base}/3.5/IEDriverServer_Win32_3.5.0.zip",
+              Gem::Version.new('3.5.1') => "#{base}/3.5/IEDriverServer_Win32_3.5.1.zip"}
+      allow(iedriver).to receive(:downloads).and_return(hash)
+      allow(Webdrivers::System).to receive(:valid_cache?)
+
+      expect(iedriver.latest_version).to eq Gem::Version.new('3.5.1')
+      expect(iedriver).to have_received(:downloads)
+      expect(Webdrivers::System).to have_received(:valid_cache?)
+    end
   end
 
   describe '#required_version=' do


### PR DESCRIPTION
This creates a `#{driver_path}.version` file, and we read its modified date on the first lookup. There might still be a race condition, but I think it'll solve #77 well enough?

The idea is to set the default value in 3.x to 0, but allow people to set it if they want.
Then 4.x will be set by default to 1 day (86_400)

Note that for Chrome if a major browser version update has happened, it will ignore the cache, so effectively this is only preventing using a newer point release up to the expiration of the `cache_time`

