### PR TITLE
locate Chrome the same way as chromedriver 

### DIFF
--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -1,0 +1,69 @@
+# frozen_string_literal: true
+
+module Webdrivers
+  class ChromeFinder
+    class << self
+      def version
+        location = Selenium::WebDriver::Chrome.path || send("#{System.platform}_location")
+        version = send("#{System.platform}_version", location)
+
+        raise VersionError, 'Failed to find Chrome binary or its version.' if version.nil? || version.empty?
+
+        Webdrivers.logger.debug "Browser version: #{version}"
+        version[/\d+\.\d+\.\d+\.\d+/] # Google Chrome 73.0.3683.75 -> 73.0.3683.75
+      end
+
+      def win_location
+        return Selenium::WebDriver::Chrome.path unless Selenium::WebDriver::Chrome.path.nil?
+
+        envs = %w[LOCALAPPDATA PROGRAMFILES PROGRAMFILES(X86)]
+        directories = ['\\Google\\Chrome\\Application', '\\Chromium\\Application']
+        file = 'chrome.exe'
+
+        directories.each do |dir|
+          envs.each do |root|
+            option = "#{ENV[root]}\\#{dir}\\#{file}"
+            return option if File.exist?(option)
+          end
+        end
+      end
+
+      def mac_location
+        directories = ['', File.expand_path('~')]
+        files = ['/Applications/Google Chrome.app/Contents/MacOS/Google Chrome',
+                 '/Applications/Chromium.app/Contents/MacOS/Chromium']
+
+        directories.each do |dir|
+          files.each do |file|
+            option = "#{dir}/#{file}"
+            return option if File.exist?(option)
+          end
+        end
+      end
+
+      def linux_location
+        directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /opt/google/chrome]
+        files = %w[google-chrome chrome chromium chromium-browser]
+
+        directories.each do |dir|
+          files.each do |file|
+            option = "#{dir}/#{file}"
+            return option if File.exist?(option)
+          end
+        end
+      end
+
+      def win_version(location)
+        System.call("powershell (Get-ItemProperty '#{location}').VersionInfo.ProductVersion")&.strip
+      end
+
+      def linux_version(location)
+        System.call("#{Shellwords.escape location} --product-version")&.strip
+      end
+
+      def mac_version(location)
+        System.call("#{Shellwords.escape location} --version")&.strip
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fixes #45 

I think I got this working the same was as Google.
It appears to work on Linux, Windows, JRuby & Mac for the testing environments we have at least.

Would it make sense to fall back to what we were doing before? chromedriver does not do anything with ENV or Registry like we were doing, though.

Since it's a potentially breaking change, the idea is to release this in a 4.0.alpha and get feedback from people as to whether it's working for them.