### PR TITLE
ensure the driver file is also present after validating the cache file

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -24,7 +24,7 @@ Metrics/BlockLength:
     - 'spec/**/*'
 
 Metrics/ClassLength:
-  Max: 116
+  Max: 119
 
 Metrics/CyclomaticComplexity:
   Max: 8

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -39,10 +39,20 @@ module Webdrivers
       end
 
       def valid_cache?(file_name)
-        file = "#{install_dir}/#{file_name.gsub('.exe', '')}.version"
-        return false unless File.exist?(file)
+        driver_file = "#{install_dir}/#{file_name.gsub('.exe', '')}"
+        cache_file = "#{driver_file}.version"
+        return false unless File.exist?(cache_file)
 
-        Time.now - File.mtime(file) < Webdrivers.cache_time
+        return false if Time.now - File.mtime(cache_file) < Webdrivers.cache_time
+
+        begin
+          Selenium::WebDriver::Wait.new(timeout: 30, interval: 0.1).until do
+            File.exist?(driver_file)
+          end
+          return true
+        rescue TimeoutError
+          return false
+        end
       end
 
       def download(url, target)


### PR DESCRIPTION
This is kind of whack-a-mole with the race conditions for #77...

User is reporting `ChildProcess::LaunchError: Text file busy`, which means that it is attempting to start a file that is currently open for writing. 

The scenario I'm picturing for 2 processes running in parallel:
1 - Sees no version file and creates it
2 - Sees a version file and continues on
1 - Downloads / Extracts driver
2 - Tries to use the driver before it is finished being downloaded/extracted

Waiting for the driver to exist after validating that it should not be downloaded again should be sufficient for this particular race condition.

The tricky part here is determining how long it should take for a driver to be downloaded and extracted, etc, and how to recover from an unforeseen state.

I don't think there's going to be a good way to completely solve this 100%. The right answer might be the rake tasks in #28 