### PR TITLE
Add executables for chromedriver and geckodriver

### DIFF
--- a/bin/webdrivers-chromedriver
+++ b/bin/webdrivers-chromedriver
@@ -1,0 +1,6 @@
+#! /usr/bin/env ruby
+
+require_relative '../lib/webdrivers/chromedriver'
+
+Webdrivers::Chromedriver.update 
+exec Webdrivers::Chromedriver.driver_path, *ARGV

--- a/bin/webdrivers-chromedriver
+++ b/bin/webdrivers-chromedriver
@@ -1,6 +1,6 @@
 #! /usr/bin/env ruby
+# frozen_string_literal: true
 
 require_relative '../lib/webdrivers/chromedriver'
 
-Webdrivers::Chromedriver.update 
-exec Webdrivers::Chromedriver.driver_path, *ARGV
+Webdrivers::Chromedriver.run(*ARGV)

--- a/bin/webdrivers-geckodriver
+++ b/bin/webdrivers-geckodriver
@@ -1,0 +1,6 @@
+#! /usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative '../lib/webdrivers/geckodriver'
+
+Webdrivers::Geckodriver.run(*ARGV)

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'shellwords'
-require 'webdrivers/common'
+require_relative 'common'
 
 module Webdrivers
   class Chromedriver < Common

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -129,6 +129,14 @@ end
         File.join System.install_dir, file_name
       end
 
+      #
+      # Performs an update check and then runs the execuable
+      # with the provided *args*
+      def run(*args)
+        update
+        exec driver_path, *args
+      end
+
       private
 
       def download_url

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -2,9 +2,9 @@
 
 require 'rubygems/package'
 require 'zip'
-require 'webdrivers/logger'
-require 'webdrivers/network'
-require 'webdrivers/system'
+require_relative 'logger'
+require_relative 'network'
+require_relative 'system'
 require 'selenium-webdriver'
 
 module Webdrivers

--- a/lib/webdrivers/geckodriver.rb
+++ b/lib/webdrivers/geckodriver.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require 'nokogiri'
-require 'webdrivers/common'
+require_relative 'common'
 
 module Webdrivers
   class Geckodriver < Common

--- a/lib/webdrivers/network.rb
+++ b/lib/webdrivers/network.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'net/http'
+
 module Webdrivers
   #
   # @api private


### PR DESCRIPTION
This adds executables similar to [`chromedriver-helper`](https://github.com/flavorjones/chromedriver-helper/tree/master/bin) and [`geckodriver-helper
`](https://github.com/DevicoSolutions/geckodriver-helper/tree/master/bin)

```sh
➤  bin/webdrivers-chromedriver --version                                                                                                                                          130 ↵
2019-05-14 16:32:54 WARN Webdrivers Driver caching is turned off in this version, but will be enabled by default in 4.x. Set the value with `Webdrivers#cache_time=` in seconds
ChromeDriver 74.0.3729.6 (255758eccf3d244491b8a1317aa76e1ce10d57e9-refs/branch-heads/3729@{#29})

➤  bin/webdrivers-geckodriver --version 
2019-05-14 16:33:03 WARN Webdrivers Driver caching is turned off in this version, but will be enabled by default in 4.x. Set the value with `Webdrivers#cache_time=` in seconds
geckodriver 0.24.0 ( 2019-01-28)

The source code of this program is available from
testing/geckodriver in https://hg.mozilla.org/mozilla-central.

This program is subject to the terms of the Mozilla Public License 2.0.
You can obtain a copy of the license at https://mozilla.org/MPL/2.0/.
```