### PR TITLE
Disable warning about caching in 4.x when setting `Webdrivers.cache_t…

### DIFF
--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -20,13 +20,20 @@ module Webdrivers
   class << self
     attr_accessor :proxy_addr, :proxy_port, :proxy_user, :proxy_pass, :install_dir
 
-    attr_writer :cache_time
-
     #
     # Returns the amount of time (Seconds) the gem waits between two update checks.
     #
     def cache_time
       @cache_time || 0
+    end
+
+    #
+    # Set the amount of time (Seconds) the gem waits between two update checks. Disable
+    # Common.cache_warning.
+    #
+    def cache_time=(value)
+      Common.cache_warning = true
+      @cache_time = value
     end
 
     def logger
@@ -58,7 +65,7 @@ end
   class Common
     class << self
       attr_writer :required_version
-      attr_reader :cache_warning
+      attr_accessor :cache_warning
 
       def version
         Webdrivers.logger.deprecate("#{self.class}#version", "#{self.class}#required_version")


### PR DESCRIPTION
Hi there!

I recently updated to webdrivers v3.9.2 and found that setting `Webdrivers.cache_time` as mentioned in the warning about caching doesn't remove the warning.  This was kind of confusing and could be a problem on teams that are fastidious about ensuring there are no warnings or deprecations when running tests.  

I looked through the tests and didn't see anywhere that it made sense to add test coverage.  I see the behavior around `cache_time` is checked, but nothing for `cache_warning`.  Let me know if test coverage is a must for PRs.  

Thanks for the work on this gem.  