### PR TITLE
Fix comparison of Float with String failed when WD_CACHE_TIME is set

### DIFF
--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -45,7 +45,7 @@ module Webdrivers
         file = "#{install_dir}/#{file_name.gsub('.exe', '')}.version"
         return false unless File.exist?(file)
 
-        Time.now - File.mtime(file) < Webdrivers.cache_time
+        Time.now - File.mtime(file) < Webdrivers.cache_time.to_i
       end
 
       def download(url, target)


### PR DESCRIPTION
⚠️ This PR code has not been tested as I am using Semaphore 1.0 which does not rely on threads for parallel tests. But I thought I would share it if it can help :)

### command

`bundle exec rake webdrivers:chromedriver:update WD_CACHE_TIME=86_400 WD_INSTALL_DIR=$SEMAPHORE_CACHE_DIR`

### stacktrace
```
ArgumentError: comparison of Float with String failed
/home/runner/dossier/vendor/bundle/ruby/2.4.0/gems/webdrivers-4.0.0.rc1/lib/webdrivers/system.rb:48:in `<'
/home/runner/dossier/vendor/bundle/ruby/2.4.0/gems/webdrivers-4.0.0.rc1/lib/webdrivers/system.rb:48:in `valid_cache?'
/home/runner/dossier/vendor/bundle/ruby/2.4.0/gems/webdrivers-4.0.0.rc1/lib/webdrivers/common.rb:153:in `with_cache'
/home/runner/dossier/vendor/bundle/ruby/2.4.0/gems/webdrivers-4.0.0.rc1/lib/webdrivers/chromedriver.rb:34:in `latest_version'
/home/runner/dossier/vendor/bundle/ruby/2.4.0/gems/webdrivers-4.0.0.rc1/lib/webdrivers/common.rb:127:in `correct_binary?'
/home/runner/dossier/vendor/bundle/ruby/2.4.0/gems/webdrivers-4.0.0.rc1/lib/webdrivers/common.rb:83:in `update'
/home/runner/dossier/vendor/bundle/ruby/2.4.0/gems/webdrivers-4.0.0.rc1/lib/webdrivers/tasks/chromedriver.rake:25
```