### PR TITLE
Initial addition of Edge Chrome to webdrivers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ pkg/*
 chromedriver.log
 /.idea/
 coverage/
+gemfiles/Gemfile.*.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ addons:
       - libgconf-2-4
   chrome: stable
 script: bundle exec rake $RAKE_TASK
+before_install:
+  - gem update --system
+  - gem update bundler
 matrix:
   include:
     - rvm: 2.6.3
@@ -22,3 +25,16 @@ matrix:
       env: RAKE_TASK=rubocop
     - rvm: jruby-9.2.7.0
       env: RAKE_TASK=spec
+    - rvm: 2.6
+      env: RAKE_TASK=spec
+      gemfile: gemfiles/Gemfile.edge
+      os: osx
+      osx_image: xcode10.2
+      addons:
+        chrome: stable
+        homebrew:
+          taps: homebrew/cask-versions
+          casks:
+            - microsoft-edge-canary
+  allow_failures:
+    - gemfile: gemfiles/Gemfile.edge

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,11 @@ environment:
       RUBY_BIN: jruby
       RAKE_TASK: spec
       SCRIPT_CONTEXT: jruby -G -S
+    - RUBY_VERSION: Ruby26
+      RUBY_BIN: ruby
+      RAKE_TASK: spec
+      SCRIPT_CONTEXT: bundle exec
+      BUNDLE_GEMFILE: gemfiles/Gemfile.edge
 install:
   - ps: if ($env:RUBY_BIN -eq 'jruby') { support\install_jruby.ps1 }
   - ps: support\install_msedge.ps1

--- a/gemfiles/Gemfile.edge
+++ b/gemfiles/Gemfile.edge
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+source 'https://rubygems.org'
+
+# Specify your gem's dependencies in webdrivers.gemspec
+gemspec path: '..'
+gem 'selenium-webdriver', github: 'seleniumhq/selenium', branch: 'edge_chrome_rb', glob: 'rb/*.gemspec'

--- a/gemfiles/Gemfile.edge
+++ b/gemfiles/Gemfile.edge
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in webdrivers.gemspec
 gemspec path: '..'
-gem 'selenium-webdriver', github: 'seleniumhq/selenium', branch: 'edge_chrome_rb', glob: 'rb/*.gemspec'
+gem 'selenium-webdriver', github: 'seleniumhq/selenium', glob: 'rb/*.gemspec'

--- a/lib/webdrivers.rb
+++ b/lib/webdrivers.rb
@@ -2,5 +2,6 @@
 
 require 'webdrivers/chromedriver'
 require 'webdrivers/geckodriver'
+require 'webdrivers/edgedriver'
 require 'webdrivers/iedriver'
 require 'webdrivers/railtie' if defined?(Rails)

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -42,9 +42,10 @@ module Webdrivers
       # Returns currently installed Chrome/Chromium version.
       #
       # @return [Gem::Version]
-      def chrome_version
+      def browser_version
         normalize_version ChromeFinder.version
       end
+      alias chrome_version browser_version
 
       #
       # Returns url with domain for calls to get this driver.
@@ -102,7 +103,7 @@ module Webdrivers
       # @example
       #   73.0.3683.75 -> 73.0.3683
       def release_version
-        chrome = normalize_version(chrome_version)
+        chrome = normalize_version(browser_version)
         normalize_version(chrome.segments[0..2].join('.'))
       end
 

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+module Webdrivers
+  class EdgeFinder
+    class << self
+      def version
+        location = Selenium::WebDriver::EdgeChrome.path || send("#{System.platform}_location")
+        version = send("#{System.platform}_version", location)
+
+        raise VersionError, 'Failed to find Edge binary or its version.' if version.nil? || version.empty?
+
+        Webdrivers.logger.debug "Browser version: #{version}"
+        version[/\d+\.\d+\.\d+\.\d+/] # Microsoft Edge 73.0.3683.75 -> 73.0.3683.75
+      end
+
+      def win_location
+        return Selenium::WebDriver::Edge.path unless Selenium::WebDriver::Edge.path.nil?
+
+        # TODO: Need to figure out what these are
+        raise 'Not yet implemented'
+        # envs = %w[LOCALAPPDATA PROGRAMFILES PROGRAMFILES(X86)]
+        # directories = ['\\Google\\Chrome\\Application', '\\Chromium\\Application']
+        # file = 'chrome.exe'
+        #
+        # directories.each do |dir|
+        #   envs.each do |root|
+        #     option = "#{ENV[root]}\\#{dir}\\#{file}"
+        #     return option if File.exist?(option)
+        #   end
+        # end
+      end
+
+      def mac_location
+        directories = ['', File.expand_path('~')]
+        files = ['/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary']
+
+        directories.each do |dir|
+          files.each do |file|
+            option = "#{dir}/#{file}"
+            return option if File.exist?(option)
+          end
+        end
+      end
+
+      def linux_location
+        raise 'Default location not yet known'
+      end
+
+      def win_version(location)
+        System.call("powershell (Get-ItemProperty '#{location}').VersionInfo.ProductVersion")&.strip
+      end
+
+      def linux_version(location)
+        System.call("#{Shellwords.escape location} --product-version")&.strip
+      end
+
+      def mac_version(location)
+        System.call("#{Shellwords.escape location} --version")&.strip
+      end
+    end
+  end
+end

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -15,7 +15,7 @@ module Webdrivers
 
       def win_location
         envs = %w[LOCALAPPDATA PROGRAMFILES PROGRAMFILES(X86)]
-        directories = ['\\Microsoft\\Edge SxS\\Application', '\\Microsoft\\Edge Dev\\Application']
+        directories = ['\\Microsoft\\Edge Dev\\Application', '\\Microsoft\\Edge SxS\\Application']
         file = 'msedge.exe'
 
         directories.each do |dir|
@@ -34,9 +34,9 @@ module Webdrivers
 
       def mac_location
         directories = ['', File.expand_path('~')]
-        files = ['/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary',
+        files = ['/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
                  '/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev',
-                 '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge']
+                 '/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary']
 
         directories.each do |dir|
           files.each do |file|

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -5,7 +5,7 @@ module Webdrivers
     class << self
       def version
         location = Selenium::WebDriver::EdgeChrome.path || send("#{System.platform}_location")
-        version = send("#{System.platform}_version", System.escape_path(location))
+        version = send("#{System.platform}_version", System.escape_path(location)) if location
 
         raise VersionError, 'Failed to find Edge binary or its version.' if version.nil? || version.empty?
 
@@ -29,6 +29,7 @@ module Webdrivers
             return option
           end
         end
+        nil
       end
 
       def mac_location
@@ -43,6 +44,7 @@ module Webdrivers
             return option if File.exist?(option)
           end
         end
+        nil
       end
 
       def linux_location

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -14,20 +14,16 @@ module Webdrivers
       end
 
       def win_location
-        return Selenium::WebDriver::Edge.path unless Selenium::WebDriver::Edge.path.nil?
+        envs = %w[LOCALAPPDATA PROGRAMFILES PROGRAMFILES(X86)]
+        directories = ['\\Microsoft\\Edge SxS\\Application', '\\Microsoft\\Edge Dev\\Application']
+        file = 'msedge.exe'
 
-        # TODO: Need to figure out what these are
-        raise 'Not yet implemented'
-        # envs = %w[LOCALAPPDATA PROGRAMFILES PROGRAMFILES(X86)]
-        # directories = ['\\Google\\Chrome\\Application', '\\Chromium\\Application']
-        # file = 'chrome.exe'
-        #
-        # directories.each do |dir|
-        #   envs.each do |root|
-        #     option = "#{ENV[root]}\\#{dir}\\#{file}"
-        #     return option if File.exist?(option)
-        #   end
-        # end
+        directories.each do |dir|
+          envs.each do |root|
+            option = "#{ENV[root]}\\#{dir}\\#{file}"
+            return option if File.exist?(option)
+          end
+        end
       end
 
       def mac_location

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -32,7 +32,9 @@ module Webdrivers
 
       def mac_location
         directories = ['', File.expand_path('~')]
-        files = ['/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary']
+        files = ['/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary',
+                 '/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev',
+                 '/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge']
 
         directories.each do |dir|
           files.each do |file|

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -5,7 +5,7 @@ module Webdrivers
     class << self
       def version
         location = Selenium::WebDriver::EdgeChrome.path || send("#{System.platform}_location")
-        version = send("#{System.platform}_version", location)
+        version = send("#{System.platform}_version", System.escape_path(location))
 
         raise VersionError, 'Failed to find Edge binary or its version.' if version.nil? || version.empty?
 
@@ -21,7 +21,12 @@ module Webdrivers
         directories.each do |dir|
           envs.each do |root|
             option = "#{ENV[root]}\\#{dir}\\#{file}"
-            return option if File.exist?(option)
+            next unless File.exist?(option)
+
+            # Escape space and parenthesis with backticks.
+            option = option.gsub(/([\s()])/, '`\1') if RUBY_PLATFORM == 'java'
+
+            return option
           end
         end
       end
@@ -49,11 +54,11 @@ module Webdrivers
       end
 
       def linux_version(location)
-        System.call("#{Shellwords.escape location} --product-version")&.strip
+        System.call("#{location} --product-version")&.strip
       end
 
       def mac_version(location)
-        System.call("#{Shellwords.escape location} --version")&.strip
+        System.call("#{location} --version")&.strip
       end
     end
   end

--- a/lib/webdrivers/edgedriver.rb
+++ b/lib/webdrivers/edgedriver.rb
@@ -8,24 +8,12 @@ require 'webdrivers/edge_finder'
 module Webdrivers
   class Edgedriver < Chromedriver
     class << self
+      undef :chrome_version
       #
-      # Returns latest available chromedriver version.
-      #
-      # @return [Gem::Version]
-      def latest_version
-        @latest_version ||= begin
-          latest_applicable = with_cache(file_name) { latest_point_release(release_version) }
-
-          Webdrivers.logger.debug "Latest version available: #{latest_applicable}"
-          normalize_version(latest_applicable)
-        end
-      end
-
-      #
-      # Returns currently installed Chrome/Chromium version.
+      # Returns currently installed Edge version.
       #
       # @return [Gem::Version]
-      def edge_version
+      def browser_version
         normalize_version EdgeFinder.version
       end
 
@@ -88,19 +76,6 @@ module Webdrivers
         url = downloads[version]
         Webdrivers.logger.debug "edgedriver URL: #{url}"
         @download_url = url
-      end
-
-      # Returns release version from the currently installed Chrome version
-      #
-      # @example
-      #   73.0.3683.75 -> 73.0.3683
-      def release_version
-        edge = normalize_version(edge_version)
-        normalize_version(edge.segments[0..2].join('.'))
-      end
-
-      def sufficient_binary?
-        super && current_version && (current_version.segments.first == release_version.segments.first)
       end
 
       def downloads

--- a/lib/webdrivers/edgedriver.rb
+++ b/lib/webdrivers/edgedriver.rb
@@ -1,0 +1,145 @@
+# frozen_string_literal: true
+
+require 'shellwords'
+require 'webdrivers/common'
+require 'webdrivers/edgedriver'
+require 'webdrivers/edge_finder'
+
+module Webdrivers
+  class Edgedriver < Chromedriver
+    class << self
+      #
+      # Returns latest available chromedriver version.
+      #
+      # @return [Gem::Version]
+      def latest_version
+        @latest_version ||= begin
+          latest_applicable = with_cache(file_name) { latest_point_release(release_version) }
+
+          Webdrivers.logger.debug "Latest version available: #{latest_applicable}"
+          normalize_version(latest_applicable)
+        end
+      end
+
+      #
+      # Returns currently installed Chrome/Chromium version.
+      #
+      # @return [Gem::Version]
+      def edge_version
+        normalize_version EdgeFinder.version
+      end
+
+      #
+      # Returns url with domain for calls to get this driver.
+      #
+      # @return [String]
+      def base_url
+        'https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
+      end
+
+      def remove
+        super
+        @downloads = nil
+      end
+
+      private
+
+      def latest_point_release(version)
+        begin
+          lpr = downloads.keys.select { |ver| ver.segments[0..2] == version.segments[0..2] }.max
+          return normalize_version(lpr) if lpr
+        rescue NetworkError # rubocop:disable Lint/HandleExceptions
+        end
+        msg = failed_to_find_message(version)
+        Webdrivers.logger.debug msg
+        raise VersionError, msg
+      end
+
+      def failed_to_find_message(version)
+        msg = "Unable to find latest point release version for #{version}."
+        msg = begin
+          latest_release = normalize_version(downloads.keys.max)
+          if version > latest_release
+            "#{msg} You appear to be using a non-production version of Edge."
+          else
+            msg
+          end
+              rescue NetworkError
+                "#{msg} A network issue is preventing determination of latest msedgedriver release."
+        end
+
+        "#{msg} Please set `Webdrivers::Edgedriver.required_version = <desired driver version>` "\
+        "to a known edgedriver version: #{base_url}"
+      end
+
+      def file_name
+        System.platform == 'win' ? 'msedgedriver.exe' : 'msedgedriver'
+      end
+
+      def download_url
+        return @download_url if @download_url
+
+        version = if required_version == EMPTY_VERSION
+                    latest_version
+                  else
+                    normalize_version(required_version)
+                  end
+
+        url = downloads[version]
+        Webdrivers.logger.debug "edgedriver URL: #{url}"
+        @download_url = url
+      end
+
+      # Returns release version from the currently installed Chrome version
+      #
+      # @example
+      #   73.0.3683.75 -> 73.0.3683
+      def release_version
+        edge = normalize_version(edge_version)
+        normalize_version(edge.segments[0..2].join('.'))
+      end
+
+      def sufficient_binary?
+        super && current_version && (current_version.segments.first == release_version.segments.first)
+      end
+
+      def downloads
+        @downloads ||= begin
+          ds = parse_downloads(Network.get(base_url))
+          Webdrivers.logger.debug "Versions now located on downloads site: #{ds.keys}"
+          ds
+                       rescue Webdrivers::NetworkError
+                         {}
+        end
+      end
+
+      def parse_downloads(html)
+        driver_download_url = 'https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/'
+        doc = Nokogiri::XML.parse(html)
+        doc.css(".driver-download__meta a[href^='#{driver_download_url}']")
+           .map { |a| a['href'] }
+           .select { |item| item.include?(System.platform == 'win' ? 'win32' : "#{System.platform}64") }
+           .each_with_object({}) do |url, hash|
+             hash[normalize_version url[%r{/([0-9\.]+)/edgedriver_(.*)\.zip$}, 1]] = url
+           end
+      end
+    end
+  end
+end
+
+if defined? Selenium::WebDriver::EdgeChrome
+  if ::Selenium::WebDriver::Service.respond_to? :driver_path=
+    ::Selenium::WebDriver::EdgeChrome::Service.driver_path = proc { ::Webdrivers::Edgedriver.update }
+  else
+    # v3.141.0 and lower
+    module Selenium
+      module WebDriver
+        module EdgeChrome
+          def self.driver_path
+            @driver_path ||= Webdrivers::Edgedriver.update
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -31,7 +31,7 @@ describe Webdrivers::Chromedriver do
       it 'does not download when offline, binary exists and matches major browser version' do
         allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
         allow(chromedriver).to receive(:exists?).and_return(true)
-        allow(chromedriver).to receive(:chrome_version).and_return(Gem::Version.new('73.0.3683.68'))
+        allow(chromedriver).to receive(:browser_version).and_return(Gem::Version.new('73.0.3683.68'))
         allow(chromedriver).to receive(:current_version).and_return(Gem::Version.new('73.0.3683.20'))
 
         chromedriver.update
@@ -44,7 +44,7 @@ describe Webdrivers::Chromedriver do
 
         allow(Webdrivers::Network).to receive(:get_response).and_return(client_error)
         allow(chromedriver).to receive(:exists?).and_return(true)
-        allow(chromedriver).to receive(:chrome_version).and_return(Gem::Version.new('73.0.3683.68'))
+        allow(chromedriver).to receive(:browser_version).and_return(Gem::Version.new('73.0.3683.68'))
         allow(chromedriver).to receive(:current_version).and_return(Gem::Version.new('73.0.3683.20'))
 
         chromedriver.update
@@ -55,7 +55,7 @@ describe Webdrivers::Chromedriver do
       it 'raises ConnectionError when offline, and binary does not match major browser version' do
         allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
         allow(chromedriver).to receive(:exists?).and_return(true)
-        allow(chromedriver).to receive(:chrome_version).and_return(Gem::Version.new('73.0.3683.68'))
+        allow(chromedriver).to receive(:browser_version).and_return(Gem::Version.new('73.0.3683.68'))
         allow(chromedriver).to receive(:current_version).and_return(Gem::Version.new('72.0.0.0'))
 
         msg = %r{Can not reach https://chromedriver.storage.googleapis.com}
@@ -108,7 +108,7 @@ describe Webdrivers::Chromedriver do
 
     it 'makes a network call if cached driver does not match the browser' do
       Webdrivers::System.cache_version('chromedriver', '71.0.3578.137')
-      allow(chromedriver).to receive(:chrome_version).and_return(Gem::Version.new('73.0.3683.68'))
+      allow(chromedriver).to receive(:browser_version).and_return(Gem::Version.new('73.0.3683.68'))
       allow(Webdrivers::Network).to receive(:get).and_return('73.0.3683.68')
       allow(Webdrivers::System).to receive(:download)
 
@@ -155,19 +155,19 @@ describe Webdrivers::Chromedriver do
 
   describe '#latest_version' do
     it 'returns 2.41 if the browser version is less than 70' do
-      allow(chromedriver).to receive(:chrome_version).and_return('69.0.0')
+      allow(chromedriver).to receive(:browser_version).and_return('69.0.0')
 
       expect(chromedriver.latest_version).to eq(Gem::Version.new('2.41'))
     end
 
     it 'returns the correct point release for a production version greater than 70' do
-      allow(chromedriver).to receive(:chrome_version).and_return '71.0.3578.9999'
+      allow(chromedriver).to receive(:browser_version).and_return '71.0.3578.9999'
 
       expect(chromedriver.latest_version).to eq Gem::Version.new('71.0.3578.137')
     end
 
     it 'raises VersionError for beta version' do
-      allow(chromedriver).to receive(:chrome_version).and_return('100.0.0')
+      allow(chromedriver).to receive(:browser_version).and_return('100.0.0')
       msg = 'Unable to find latest point release version for 100.0.0. '\
 'You appear to be using a non-production version of Chrome. '\
 'Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` '\
@@ -177,7 +177,7 @@ describe Webdrivers::Chromedriver do
     end
 
     it 'raises VersionError for unknown version' do
-      allow(chromedriver).to receive(:chrome_version).and_return('72.0.9999.0000')
+      allow(chromedriver).to receive(:browser_version).and_return('72.0.9999.0000')
       msg = 'Unable to find latest point release version for 72.0.9999. '\
 'Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` '\
 'to a known chromedriver version: https://chromedriver.storage.googleapis.com/index.html'
@@ -258,14 +258,14 @@ describe Webdrivers::Chromedriver do
     end
   end
 
-  describe '#chrome_version' do
+  describe '#browser_version' do
     it 'returns a Gem::Version object' do
-      expect(chromedriver.chrome_version).to be_an_instance_of(Gem::Version)
+      expect(chromedriver.browser_version).to be_an_instance_of(Gem::Version)
     end
 
     it 'returns currently installed Chrome version' do
       allow(Webdrivers::ChromeFinder).to receive(:version).and_return('72.0.0.0')
-      expect(chromedriver.chrome_version).to be Gem::Version.new('72.0.0.0')
+      expect(chromedriver.browser_version).to be Gem::Version.new('72.0.0.0')
     end
   end
 end

--- a/spec/webdrivers/edgedriver_spec.rb
+++ b/spec/webdrivers/edgedriver_spec.rb
@@ -254,7 +254,9 @@ describe Webdrivers::Edgedriver do
 
   describe '#driver_path' do
     it 'returns full location of binary' do
-      expect(edgedriver.driver_path).to match("#{File.join(ENV['HOME'])}/.webdrivers/msedgedriver")
+      expected_bin = "msedgedriver#{'.exe' if Selenium::WebDriver::Platform.windows?}"
+      expected_path = Webdrivers::System.escape_path("#{File.join(ENV['HOME'])}/.webdrivers/#{expected_bin}")
+      expect(edgedriver.driver_path).to eq(expected_path)
     end
   end
 end

--- a/spec/webdrivers/edgedriver_spec.rb
+++ b/spec/webdrivers/edgedriver_spec.rb
@@ -1,0 +1,260 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+describe Webdrivers::Edgedriver do
+  let(:edgedriver) { described_class }
+
+  before(:all) do # rubocop:disable RSpec/BeforeAfterAll
+    # Skip these tests if version of selenium-webdriver being tested with doesn't
+    # have Chromium based Edge support
+    skip unless defined?(Selenium::WebDriver::EdgeChrome)
+  end
+
+  before { edgedriver.remove }
+
+  describe '#update' do
+    context 'when evaluating #correct_binary?' do
+      it 'does not download when latest version and current version match' do
+        allow(edgedriver).to receive(:latest_version).and_return(Gem::Version.new('76.0.0'))
+        allow(edgedriver).to receive(:current_version).and_return(Gem::Version.new('76.0.0'))
+
+        edgedriver.update
+
+        expect(edgedriver.send(:exists?)).to be false
+      end
+
+      it 'does not download when offline, binary exists and matches major browser version' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(edgedriver).to receive(:exists?).and_return(true)
+        allow(edgedriver).to receive(:edge_version).and_return(Gem::Version.new('73.0.3683.68'))
+        allow(edgedriver).to receive(:current_version).and_return(Gem::Version.new('73.0.3683.20'))
+
+        edgedriver.update
+
+        expect(File.exist?(edgedriver.driver_path)).to be false
+      end
+
+      it 'does not download when get raises exception, binary exists and matches major browser version' do
+        client_error = instance_double(Net::HTTPNotFound, class: Net::HTTPNotFound, code: 404, message: '')
+
+        allow(Webdrivers::Network).to receive(:get_response).and_return(client_error)
+        allow(edgedriver).to receive(:exists?).and_return(true)
+        allow(edgedriver).to receive(:edge_version).and_return(Gem::Version.new('73.0.3683.68'))
+        allow(edgedriver).to receive(:current_version).and_return(Gem::Version.new('73.0.3683.20'))
+        edgedriver.update
+
+        expect(File.exist?(edgedriver.driver_path)).to be false
+      end
+
+      it 'raises ConnectionError when offline, and binary does not match major browser version' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(edgedriver).to receive(:exists?).and_return(true)
+        allow(edgedriver).to receive(:edge_version).and_return(Gem::Version.new('73.0.3683.68'))
+        allow(edgedriver).to receive(:current_version).and_return(Gem::Version.new('72.0.0.0'))
+
+        msg = %r{Can not reach https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/}
+        expect { edgedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+      end
+
+      it 'raises ConnectionError when offline, and no binary exists' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+        allow(edgedriver).to receive(:exists?).and_return(false)
+
+        msg = %r{Can not reach https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/}
+        expect { edgedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+      end
+    end
+
+    context 'when correct binary is found' do
+      before { allow(edgedriver).to receive(:correct_binary?).and_return(true) }
+
+      it 'does not download' do
+        edgedriver.update
+
+        expect(edgedriver.current_version).to be_nil
+      end
+
+      it 'does not raise exception if offline' do
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        edgedriver.update
+
+        expect(edgedriver.current_version).to be_nil
+      end
+    end
+
+    context 'when correct binary is not found' do
+      before { allow(edgedriver).to receive(:correct_binary?).and_return(false) }
+
+      it 'downloads binary' do
+        allow(edgedriver).to receive(:edge_version).and_return('76.0.168.154')
+        edgedriver.update
+
+        expect(edgedriver.current_version).not_to be_nil
+      end
+
+      it 'raises ConnectionError if offline' do
+        allow(edgedriver).to receive(:edge_version).and_return('76.0.168.154')
+        allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+        msg = %r{Can not reach https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/}
+        expect { edgedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
+      end
+    end
+
+    it 'makes a network call if cached driver does not match the browser' do
+      Webdrivers::System.cache_version('msedgedriver', '71.0.3578.137')
+      allow(edgedriver).to receive(:edge_version).and_return(Gem::Version.new('73.0.3683.68'))
+      allow(edgedriver).to receive(:downloads).and_return(Gem::Version.new('73.0.3683.68') => 'http://some/driver/path')
+
+      allow(Webdrivers::System).to receive(:download)
+
+      edgedriver.update
+
+      expect(edgedriver).to have_received(:downloads).at_least(:once)
+      expect(Webdrivers::System).to have_received(:download).once
+    end
+
+    context 'when required version is 0' do
+      it 'downloads the latest version' do
+        allow(edgedriver).to receive(:latest_version).and_return(Gem::Version.new('76.0.168.0'))
+        edgedriver.required_version = 0
+        edgedriver.update
+        expect(edgedriver.current_version.version).to eq('76.0.168.0')
+      end
+    end
+
+    context 'when required version is nil' do
+      it 'downloads the latest version' do
+        allow(edgedriver).to receive(:latest_version).and_return(Gem::Version.new('76.0.168.0'))
+        edgedriver.required_version = nil
+        edgedriver.update
+        expect(edgedriver.current_version.version).to eq('76.0.168.0')
+      end
+    end
+  end
+
+  describe '#current_version' do
+    it 'returns nil if binary does not exist on the system' do
+      allow(edgedriver).to receive(:driver_path).and_return('')
+
+      expect(edgedriver.current_version).to be_nil
+    end
+
+    it 'returns a Gem::Version instance if binary is on the system' do
+      allow(edgedriver).to receive(:exists?).and_return(true)
+      allow(Webdrivers::System).to receive(:call)
+        .with("#{edgedriver.driver_path} --version")
+        .and_return '71.0.3578.137'
+
+      expect(edgedriver.current_version).to eq Gem::Version.new('71.0.3578.137')
+    end
+  end
+
+  describe '#latest_version' do
+    it 'returns the correct point release for a production version' do
+      allow(edgedriver).to receive(:edge_version).and_return '76.0.168.9999'
+
+      expect(edgedriver.latest_version).to eq Gem::Version.new('76.0.168.0')
+    end
+
+    it 'raises VersionError for beta version' do
+      allow(edgedriver).to receive(:edge_version).and_return('100.0.0')
+      msg = 'Unable to find latest point release version for 100.0.0. '\
+'You appear to be using a non-production version of Edge. '\
+'Please set `Webdrivers::Edgedriver.required_version = <desired driver version>` '\
+'to a known edgedriver version: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
+
+      expect { edgedriver.latest_version }.to raise_exception(Webdrivers::VersionError, msg)
+    end
+
+    it 'raises VersionError for unknown version' do
+      allow(edgedriver).to receive(:edge_version).and_return('72.0.9999.0000')
+      msg = 'Unable to find latest point release version for 72.0.9999. '\
+'Please set `Webdrivers::Edgedriver.required_version = <desired driver version>` '\
+'to a known edgedriver version: https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/'
+
+      expect { edgedriver.latest_version }.to raise_exception(Webdrivers::VersionError, msg)
+    end
+
+    it 'raises ConnectionError when offline' do
+      allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
+
+      msg = %r{^Can not reach https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver}
+      expect { edgedriver.latest_version }.to raise_error(Webdrivers::ConnectionError, msg)
+    end
+
+    it 'creates cached file' do
+      allow(edgedriver).to receive(:downloads).and_return(Gem::Version.new('71.0.3578.137') => 'http://some/driver/path')
+      allow(edgedriver).to receive(:edge_version).and_return('71.0.3578.137')
+      edgedriver.latest_version
+      expect(File.exist?("#{Webdrivers::System.install_dir}/msedgedriver.version")).to eq true
+    end
+
+    it 'does not make network call if cache is valid' do
+      allow(Webdrivers).to receive(:cache_time).and_return(3600)
+      Webdrivers::System.cache_version('msedgedriver', '71.0.3578.137')
+      allow(Webdrivers::Network).to receive(:get)
+
+      expect(edgedriver.latest_version).to eq Gem::Version.new('71.0.3578.137')
+
+      expect(Webdrivers::Network).not_to have_received(:get)
+    end
+
+    it 'makes a network call if cache is expired' do
+      Webdrivers::System.cache_version('msedgedriver', '71.0.3578.137')
+      allow(Webdrivers::Network).to receive(:get).and_return(<<~HTML)
+        <p class="driver-download__meta">
+          Version: 76.0.168.0 | Microsoft Edge version supported: 76 (
+          <a href="https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/76.0.168.0/edgedriver_win32.zip" aria-label="WebDriver for release number 76 x86">x86</a>,
+          <a href="https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/76.0.168.0/edgedriver_win64.zip" aria-label="WebDriver for release number 76 x64">x64</a>,
+          <a href="https://msedgewebdriverstorage.blob.core.windows.net/edgewebdriver/76.0.168.0/edgedriver_mac64.zip" aria-label="WebDriver for release number 76 Mac">Mac</a>)
+        </p>
+      HTML
+      allow(Webdrivers::System).to receive(:valid_cache?)
+      allow(edgedriver).to receive(:edge_version).and_return('76.0.168.333')
+
+      expect(edgedriver.latest_version).to eq Gem::Version.new('76.0.168.0')
+
+      expect(Webdrivers::Network).to have_received(:get)
+      expect(Webdrivers::System).to have_received(:valid_cache?)
+    end
+  end
+
+  describe '#required_version=' do
+    after { edgedriver.required_version = nil }
+
+    it 'returns the version specified as a Float' do
+      edgedriver.required_version = 73.0
+
+      expect(edgedriver.required_version).to eq Gem::Version.new('73.0')
+    end
+
+    it 'returns the version specified as a String' do
+      edgedriver.required_version = '73.0'
+
+      expect(edgedriver.required_version).to eq Gem::Version.new('73.0')
+    end
+  end
+
+  describe '#remove' do
+    it 'removes existing edgedriver' do
+      allow(edgedriver).to receive(:edge_version).and_return('76.0.168.154')
+      edgedriver.update
+
+      edgedriver.remove
+      expect(edgedriver.current_version).to be_nil
+    end
+
+    it 'does not raise exception if no edgedriver found' do
+      expect { edgedriver.remove }.not_to raise_error
+    end
+  end
+
+  describe '#driver_path' do
+    it 'returns full location of binary' do
+      expect(edgedriver.driver_path).to match("#{File.join(ENV['HOME'])}/.webdrivers/msedgedriver")
+    end
+  end
+end

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.require_paths = ['lib']
 
   s.add_development_dependency 'ffi', '~> 1.0' # For selenium-webdriver on Windows
+  s.add_development_dependency 'irb'
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~>0.66'


### PR DESCRIPTION
This adds support for Chromium based Edge and downloading of `msedgedriver` - It doesn't yet find Edge on windows -- If anyone happens to know where we should be looking for it on windows I'd love to know :).  The support currently depends on a current draft PR on selenium-webdriver.