### PR TITLE
Escape paths correctly + Run specs against JRuby on Appveyor.

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -26,6 +26,8 @@ Metrics/BlockLength:
 
 Metrics/ClassLength:
   Max: 116
+  Exclude:
+    - 'lib/webdrivers/system.rb'
 
 Metrics/CyclomaticComplexity:
   Max: 8

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,21 +3,39 @@ cache:
   - vendor/bundle
 environment:
   matrix:
-    - RUBY_VERSION: 24
+    - RUBY_VERSION: Ruby24
+      RUBY_BIN: ruby
       RAKE_TASK: spec
-    - RUBY_VERSION: 24
+      SCRIPT_CONTEXT: bundle exec
+    - RUBY_VERSION: Ruby24
+      RUBY_BIN: ruby
       RAKE_TASK: rubocop
-    - RUBY_VERSION: 25
+      SCRIPT_CONTEXT: bundle exec
+    - RUBY_VERSION: Ruby25
+      RUBY_BIN: ruby
       RAKE_TASK: spec
-    - RUBY_VERSION: 26
+      SCRIPT_CONTEXT: bundle exec
+    - RUBY_VERSION: Ruby26
+      RUBY_BIN: ruby
       RAKE_TASK: spec
+      SCRIPT_CONTEXT: bundle exec
+    - RUBY_VERSION: jruby-9.2.7.0
+      RUBY_BIN: jruby
+      RAKE_TASK: spec
+      SCRIPT_CONTEXT: jruby -G -S
 install:
-  - set PATH=C:\Ruby%RUBY_VERSION%\bin;%PATH%
-  - bundle config --local path vendor/bundle
-  - bundle install
+  - ps: |
+      if ($env:RUBY_BIN -eq 'jruby')
+      {
+        support\install_jruby.ps1
+      }
+  - set PATH=C:\%RUBY_VERSION%\bin;%PATH%
+  - '%RUBY_BIN% -S gem update --system'
+  - '%RUBY_BIN% -S gem install bundler'
+  - '%RUBY_BIN% -S bundle install'
 before_test:
-  - ruby -v
-  - gem -v
-  - bundle -v
+  - '%RUBY_BIN% -v'
+  - '%RUBY_BIN% -S gem -v'
+  - '%RUBY_BIN% -S bundle -v'
 test_script:
-  - bundle exec rake %RAKE_TASK%
+  - '%SCRIPT_CONTEXT% rake %RAKE_TASK%'

--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -29,7 +29,7 @@ module Webdrivers
             # Escape space and parenthesis with backticks.
             option = option.gsub(/([\s()])/, '`\1') if RUBY_PLATFORM == 'java'
 
-            return System.escape_path option
+            return System.escape_path(option)
           end
         end
       end
@@ -42,7 +42,7 @@ module Webdrivers
         directories.each do |dir|
           files.each do |file|
             option = "#{dir}/#{file}"
-            return System.escape_path option if File.exist?(option)
+            return System.escape_path(option) if File.exist?(option)
           end
         end
       end
@@ -54,7 +54,7 @@ module Webdrivers
         directories.each do |dir|
           files.each do |file|
             option = "#{dir}/#{file}"
-            return System.escape_path option if File.exist?(option)
+            return System.escape_path(option) if File.exist?(option)
           end
         end
       end

--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -23,7 +23,13 @@ module Webdrivers
         directories.each do |dir|
           envs.each do |root|
             option = "#{ENV[root]}\\#{dir}\\#{file}"
-            return option if File.exist?(option)
+            next unless File.exist?(option)
+
+            # Fix for JRuby on Windows - #41 and #130.
+            # Escape space and parenthesis with backticks.
+            option = option.gsub(/([\s()])/, '`\1') if RUBY_PLATFORM == 'java'
+
+            return System.escape_path option
           end
         end
       end
@@ -36,7 +42,7 @@ module Webdrivers
         directories.each do |dir|
           files.each do |file|
             option = "#{dir}/#{file}"
-            return option if File.exist?(option)
+            return System.escape_path option if File.exist?(option)
           end
         end
       end
@@ -48,7 +54,7 @@ module Webdrivers
         directories.each do |dir|
           files.each do |file|
             option = "#{dir}/#{file}"
-            return option if File.exist?(option)
+            return System.escape_path option if File.exist?(option)
           end
         end
       end
@@ -58,11 +64,11 @@ module Webdrivers
       end
 
       def linux_version(location)
-        System.call("#{Shellwords.escape location} --product-version")&.strip
+        System.call("#{location} --product-version")&.strip
       end
 
       def mac_version(location)
-        System.call("#{Shellwords.escape location} --version")&.strip
+        System.call("#{location} --version")&.strip
       end
     end
   end

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -105,7 +105,7 @@ end
       #
       # @return [String]
       def driver_path
-        File.join System.install_dir, file_name
+        System.escape_path File.join(System.install_dir, file_name)
       end
 
       private

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -149,6 +149,12 @@ module Webdrivers
         Webdrivers.logger.debug "making System call: #{cmd}"
         `#{cmd}`
       end
+
+      def escape_path(path)
+        return path.tr('/', '\\') if platform == 'win' # Windows
+
+        Shellwords.escape(path) # Linux and macOS
+      end
     end
   end
 end

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -252,7 +252,9 @@ describe Webdrivers::Chromedriver do
 
   describe '#driver_path' do
     it 'returns full location of binary' do
-      expect(chromedriver.driver_path).to match("#{File.join(ENV['HOME'])}/.webdrivers/chromedriver")
+      expected_bin = "chromedriver#{'.exe' if Selenium::WebDriver::Platform.windows?}"
+      expected_path = Webdrivers::System.escape_path("#{File.join(ENV['HOME'])}/.webdrivers/#{expected_bin}")
+      expect(chromedriver.driver_path).to eq(expected_path)
     end
   end
 end

--- a/spec/webdrivers/geckodriver_spec.rb
+++ b/spec/webdrivers/geckodriver_spec.rb
@@ -204,7 +204,9 @@ You can obtain a copy of the license at https://mozilla.org/MPL/2.0/"
 
   describe '#driver_path' do
     it 'returns full location of binary' do
-      expect(geckodriver.driver_path).to match("#{File.join(ENV['HOME'])}/.webdrivers/geckodriver")
+      expected_bin = "geckodriver#{'.exe' if Selenium::WebDriver::Platform.windows?}"
+      expected_path = Webdrivers::System.escape_path("#{File.join(ENV['HOME'])}/.webdrivers/#{expected_bin}")
+      expect(geckodriver.driver_path).to eq(expected_path)
     end
   end
 end

--- a/spec/webdrivers/i_edriver_spec.rb
+++ b/spec/webdrivers/i_edriver_spec.rb
@@ -186,7 +186,8 @@ describe Webdrivers::IEdriver do
 
   describe '#driver_path' do
     it 'returns full location of binary' do
-      expect(iedriver.driver_path).to eq("#{File.join(ENV['HOME'])}/.webdrivers/IEDriverServer.exe")
+      expected_path = Webdrivers::System.escape_path("#{File.join(ENV['HOME'])}/.webdrivers/IEDriverServer.exe")
+      expect(iedriver.driver_path).to eq(expected_path)
     end
   end
 end

--- a/support/install_jruby.ps1
+++ b/support/install_jruby.ps1
@@ -1,0 +1,7 @@
+$downloadLink = "https://repo1.maven.org/maven2/org/jruby/jruby-dist/9.2.7.0/jruby-dist-9.2.7.0-bin.zip"
+$zipPath = "c:\jruby-dist-9.2.7.0-bin.zip"
+
+Write-Host "Installing $($env:RUBY_VERSION)" -ForegroundColor cyan
+appveyor DownloadFile "$($downloadLink)" -FileName "$($zipPath)"
+7z x "$($zipPath)" -oc:\ -y # Unzip to c:\
+Write-Host "JRuby installed.`n" -ForegroundColor green


### PR DESCRIPTION
This PR addresses three things:

1. Fixes #130 and #41 (JRuby related) on Windows.
2. Fixes path separator issues on Windows:

```ruby
Failure/Error: expect(iedriver.driver_path).to eq("#{File.join(ENV['HOME'])}/.webdrivers/IEDriverServer.exe")

       expected: "C:\\Users\\Skittles/.webdrivers/IEDriverServer.exe"
            got: "C:/Users/Skittles/.webdrivers/IEDriverServer.exe"

       (compared using ==)
     # ./spec/webdrivers/i_edriver_spec.rb:189:in `block (3 levels) in <top (required)>'

```

3. Now runs specs against JRuby on Appveyor to avoid #130 in the future.  