### PR TITLE
Default cache time to 24 hours.

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,13 +82,12 @@ You can set Webdrivers to only look for updates if the previous check
 was longer ago than a specified number of seconds.
 
 ```ruby
-Webdrivers.cache_time = 86_400
+Webdrivers.cache_time = 86_400 # Default: 86,400 Seconds (24 hours)
 ```
 
 Alternatively, you can define this value via the `WD_CACHE_TIME` environment
-variable. 
-
-The default is set to 24 hours (86,400 seconds).
+variable, which takes precedence over the `Webdrivers.cache_time` value. 
+**Only set one to avoid confusion**.
 
 ### Proxy
 

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -18,15 +18,19 @@ module Webdrivers
   class NetworkError < StandardError
   end
 
+  DEFAULT_CACHE_TIME = 86_400 # 24 hours
+
   class << self
     attr_accessor :proxy_addr, :proxy_port, :proxy_user, :proxy_pass
     attr_writer :install_dir, :cache_time
 
     #
     # Returns the amount of time (Seconds) the gem waits between two update checks.
+    # @note Value from the environment variable "WD_CACHE_TIME" takes precedence over Webdrivers.cache_time. If neither
+    # are set, it defaults to 86,400 Seconds (24 hours).
     #
     def cache_time
-      (@cache_time || ENV['WD_CACHE_TIME']).to_i
+      (ENV['WD_CACHE_TIME'] || @cache_time || DEFAULT_CACHE_TIME).to_i
     end
 
     #

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -114,7 +114,7 @@ describe Webdrivers::Chromedriver do
 
       chromedriver.update
 
-      expect(Webdrivers::Network).to have_received(:get).twice
+      expect(Webdrivers::Network).to have_received(:get).once
     end
 
     context 'when required version is 0' do

--- a/spec/webdrivers/webdrivers_spec.rb
+++ b/spec/webdrivers/webdrivers_spec.rb
@@ -16,8 +16,12 @@ describe Webdrivers do
       end
     end
 
-    context 'when Webdrivers.cache_time is set as a String' do
+    context 'when Webdrivers.cache_time is set' do
       before { described_class.cache_time = '999' }
+
+      it 'returns user defined cache time' do
+        expect(described_class.cache_time).to eq(999)
+      end
 
       it 'returns cache time as an Integer' do
         expect(described_class.cache_time).to be_an_instance_of(Integer)

--- a/spec/webdrivers/webdrivers_spec.rb
+++ b/spec/webdrivers/webdrivers_spec.rb
@@ -6,32 +6,34 @@ describe Webdrivers do
   describe '#cache_time' do
     before { Webdrivers::Chromedriver.remove }
 
-    after { described_class.cache_time = 0 }
+    after { described_class.cache_time = nil }
 
-    it 'does not warn if cache time is set' do
-      described_class.cache_time = 50
-
-      msg = /Webdrivers Driver caching is turned off in this version, but will be enabled by default in 4\.x/
-      expect { Webdrivers::Chromedriver.update }.not_to output(msg).to_stdout_from_any_process
-    end
-
-    context 'when ENV variable WD_CACHE_TIME is set and Webdrivers.cache_time is not' do
+    context 'when cache time is not set' do
       before { described_class.cache_time = nil }
 
-      it 'uses cache time value from ENV variable' do
-        allow(ENV).to receive(:[]).with('WD_CACHE_TIME').and_return('999')
-        expect(described_class.cache_time).to be(999)
+      it 'defaults cache time to 86,400 Seconds (24 hours)' do
+        expect(described_class.cache_time).to eq(86_400)
       end
+    end
+
+    context 'when Webdrivers.cache_time is set as a String' do
+      before { described_class.cache_time = '999' }
 
       it 'returns cache time as an Integer' do
-        allow(ENV).to receive(:[]).with('WD_CACHE_TIME').and_return('999')
         expect(described_class.cache_time).to be_an_instance_of(Integer)
       end
     end
 
-    context 'when Webdrivers.cache_time is set' do
+    context 'when ENV variable WD_CACHE_TIME is set' do
+      before { described_class.cache_time = 86_400 }
+
+      it 'uses cache time value from ENV variable over the Webdrivers.cache_time value' do
+        allow(ENV).to receive(:[]).with('WD_CACHE_TIME').and_return(999)
+        expect(described_class.cache_time).to be(999)
+      end
+
       it 'returns cache time as an Integer' do
-        described_class.cache_time = '999'
+        allow(ENV).to receive(:fetch).with('WD_CACHE_TIME', 86_400).and_return('999')
         expect(described_class.cache_time).to be_an_instance_of(Integer)
       end
     end


### PR DESCRIPTION
Fixes #132.

This is the new/fixed order of precedence to determine the cache time:

1. Value from environment variable `WD_CACHE_TIME`
2. User defined, project specific cache time via `Webdrivers.cache_time=`
3. Default value of 86,400 Seconds (24 hours)