### PR TITLE
Add recommended config locations to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,14 @@ require 'webdrivers'
 ```
 
 The drivers will now be automatically downloaded or updated when you launch a browser
-through Selenium. 
+through Selenium.
+
+### Configuration
+
+Configuration options can be set any time before your tests run but we recommend setting them in a test helper, e.g.:
+
+- `spec/support/javascript_driver.rb` for RSpec specs
+- `test/application_system_test_case.rb` for Rails 5.1+ system tests
 
 ### Specific Drivers
 


### PR DESCRIPTION
Add recommended locations for Webdriver configuration directives to the README for RSpec Specs and Rails (5.1+) System Tests

As per issue https://github.com/titusfortner/webdrivers/issues/135

I might be missing some important information. I blindly copied the RSpec location from https://bloggie.io/@kinopyo/migrate-from-chromedriver-helper-to-webdrivers