### PR TITLE
Add new `WD_DRIVER_PATH` environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,14 @@ The logging level can be configured for debugging purpose:
 Webdrivers.logger.level = :DEBUG
 ```
 
+### Use pre-installed driver
+
+You can specify any driver path via the `WD_DRIVER_PATH` environment variable (in this case, nothing is downloaded). This feature is convenient when you want to specify a different driver path in each environment, for example, on local a downloaded driver by the gem, but on CI a pre-installed driver.
+
+```shell
+WD_DRIVER_PATH=/usr/local/bin/chromedriver rspec
+```
+
 ### Browser Specific Notes
 
 #### Chrome/Chromium

--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -114,6 +114,8 @@ module Webdrivers
       #
       # @return [String]
       def driver_path
+        return ENV['WD_DRIVER_PATH'] if ENV['WD_DRIVER_PATH']
+
         File.absolute_path File.join(System.install_dir, file_name)
       end
 

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -256,6 +256,12 @@ describe Webdrivers::Chromedriver do
       expected_path = File.absolute_path "#{File.join(ENV['HOME'])}/.webdrivers/#{expected_bin}"
       expect(chromedriver.driver_path).to eq(expected_path)
     end
+
+    it 'returns a given value of the `WD_DRIVER_PATH` environment variable' do
+      expected_path = '/path/to/chromedriver'
+      allow(ENV).to receive(:[]).with('WD_DRIVER_PATH').and_return(expected_path)
+      expect(chromedriver.driver_path).to eq(expected_path)
+    end
   end
 
   describe '#browser_version' do


### PR DESCRIPTION
Hi, thank you very much for the awesome gem!

I suggest a new feature to add a new `WD_DRIVER_PATH` environment variable and overwrite a driver path. Please let me explain the reason.

Currently, I use the gem to auto-download and auto-update ChromeDriver on my local machine and on my CircleCI environment. CircleCI has a Docker image which [bundles Ruby and the latest ChromeDriver](https://github.com/CircleCI-Public/circleci-dockerfiles/blob/4a5036b95f4f5979680f2938a23d34e927a5158e/ruby/images/2.6.3-stretch/browsers/Dockerfile#L5) and I use the image.

I want to reduce the CI build time, so I want to use the bundled ChromeDriver on the CI. Furthermore, when running parallel tests on the CI, I want to prevent duplicate download.

Thus, by using this new feature I think that I can realize the CI speed-up.

What do you think about the proposal? It would be great if I could take good feedback.
Thanks.
