### PR TITLE
Upgrade rubyzip to 1.3.0 for known vulnerability

### DIFF
--- a/lib/webdrivers/common.rb
+++ b/lib/webdrivers/common.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 require 'rubygems/package'
-require 'zip'
 require 'webdrivers/logger'
 require 'webdrivers/network'
 require 'webdrivers/system'

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -4,6 +4,12 @@ require 'rubygems/package'
 require 'zip'
 require 'English'
 
+# validate zip entry sizes to avoid zip bombs
+# see https://github.com/rubyzip/rubyzip#size-validation
+# and https://github.com/rubyzip/rubyzip/pull/403 for further details
+# this will be the default in rubyzip 2.0+
+Zip.validate_entry_sizes = true
+
 module Webdrivers
   #
   # @api private

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~>0.16'
 
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
-  s.add_runtime_dependency 'rubyzip', '>= 1.2.2'
+  s.add_runtime_dependency 'rubyzip', '>= 1.3.0'
   s.add_runtime_dependency 'selenium-webdriver', '>= 3.0', '< 4.0'
 end

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~>0.16'
 
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
-  s.add_runtime_dependency 'rubyzip', '~> 1.0'
+  s.add_runtime_dependency 'rubyzip', '~> 1.0', '>= 1.3.0'
   s.add_runtime_dependency 'selenium-webdriver', '>= 3.0', '< 4.0'
 end

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~>0.16'
 
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
-  s.add_runtime_dependency 'rubyzip', '~> 1.0', '>= 1.3.0'
+  s.add_runtime_dependency 'rubyzip', '>= 1.2.2'
   s.add_runtime_dependency 'selenium-webdriver', '>= 3.0', '< 4.0'
 end


### PR DESCRIPTION
This updates the minimum required version of rubyzip due to a known vulnerability
https://github.com/rubyzip/rubyzip/pull/403

Due to the fact that this gem downloads zip from known and trusted sources it's probably not an urgent update.