### PR TITLE
EdgeFinder now finds Edge beta on Windows and macOS.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,6 +36,6 @@ matrix:
         homebrew:
           taps: homebrew/cask-versions
           casks:
-            - microsoft-edge-dev
+            - microsoft-edge-beta
   allow_failures:
     - gemfile: gemfiles/Gemfile.edge

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Run Selenium tests more easily with automatic installation and updates for all s
 * [chromedriver](http://chromedriver.chromium.org/)
 * [geckodriver](https://github.com/mozilla/geckodriver)
 * [IEDriverServer](https://github.com/SeleniumHQ/selenium/wiki/InternetExplorerDriver)
-* [msedgedriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)  - Dev and Canary releases on Windows and macOS only
+* [msedgedriver](https://developer.microsoft.com/en-us/microsoft-edge/tools/webdriver/)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Webdrivers::Geckodriver.required_version  = '0.23.0'
 Webdrivers::IEdriver.required_version     = '3.14.0'
 
 # Edge (Chromium)
-Webdrivers::Edgedriver.required_version     = '76.0.183.0'
+Webdrivers::Edgedriver.required_version   = '76.0.183.0'
 ```
 
 You can explicitly trigger the update in your code, but this will happen

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -37,7 +37,9 @@ module Webdrivers
 
       def win_location
         envs = %w[LOCALAPPDATA PROGRAMFILES PROGRAMFILES(X86)]
-        directories = ['\\Microsoft\\Edge Dev\\Application', '\\Microsoft\\Edge SxS\\Application']
+        directories = ['\\Microsoft\\Edge Beta\\Application',
+                       '\\Microsoft\\Edge Dev\\Application',
+                       '\\Microsoft\\Edge SxS\\Application']
         file = 'msedge.exe'
 
         directories.each do |dir|
@@ -52,6 +54,7 @@ module Webdrivers
       def mac_location
         directories = ['', File.expand_path('~')]
         files = ['/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge',
+                 '/Applications/Microsoft Edge Beta.app/Contents/MacOS/Microsoft Edge Beta',
                  '/Applications/Microsoft Edge Dev.app/Contents/MacOS/Microsoft Edge Dev',
                  '/Applications/Microsoft Edge Canary.app/Contents/MacOS/Microsoft Edge Canary']
 

--- a/support/install_msedge.ps1
+++ b/support/install_msedge.ps1
@@ -1,17 +1,11 @@
-$downloadDevLink = "https://go.microsoft.com/fwlink/?linkid=2069324&Channel=Dev&language=en-us&Consent=0&IID=85213fc4-6a13-57ae-9082-72910982ede8"
-$downloadCanaryLink = "https://go.microsoft.com/fwlink/?linkid=2084706&Channel=Canary&language=en-us&Consent=0&IID=85213fc4-6a13-57ae-9082-72910982ede8"
-$devSetup = "C:\MicrosoftEdgeSetupDev.exe"
-$canarySetup = "C:\MicrosoftEdgeSetupCanary.exe"
+$downloadBetaLink = "https://go.microsoft.com/fwlink/?linkid=2069324&Channel=Dev&language=en-us&Consent=0&IID=85213fc4-6a13-57ae-9082-72910982ede8"
+$betaSetup = "C:\MicrosoftEdgeSetupBeta.exe"
 
 #  Note: We're purposely skipping the -Wait flag in Start-Process.
 #  This is because Edge auto-launches after the setup is done and
 #  Start-Process continues to indefinitely wait on that process.
-Write-Host "Installing Microsoft Edge (Dev)..." -ForegroundColor cyan
-Invoke-WebRequest $downloadDevLink -OutFile $devSetup # Download Dev
-Start-Process $devSetup # Run installer
-Write-Host "Microsoft Edge (Dev) installed.`n" -ForegroundColor green
-
-Write-Host "Installing Microsoft Edge (Canary)..." -ForegroundColor cyan
-Invoke-WebRequest $downloadCanaryLink -OutFile $canarySetup # Download Canary
-Start-Process $canarySetup # Run installer
-Write-Host "Microsoft Edge (Canary) installed.`n" -ForegroundColor green
+Write-Host "Downloading Microsoft Edge (Beta)..." -ForegroundColor cyan
+Invoke-WebRequest $downloadBetaLink -OutFile $betaSetup
+Write-Host "Installing..." -ForegroundColor cyan
+Start-Process $betaSetup
+Write-Host "Microsoft Edge (Beta) installed.`n" -ForegroundColor green


### PR DESCRIPTION
Also updated Appveyor and Travis configs to only install the Beta build. No point installing others as the first one found will always be used for the tests.