### PR TITLE
Add required_ruby_version 

### DIFF
--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -19,6 +19,8 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
+  s.required_ruby_version = ">= 2.3.0"
+
   s.add_development_dependency 'ffi', '~> 1.0' # For selenium-webdriver on Windows
   s.add_development_dependency 'irb'
   s.add_development_dependency 'rake', '~> 12.0'

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
   s.require_paths = ['lib']
 
-  s.required_ruby_version = ">= 2.3.0"
+  s.required_ruby_version = '>= 2.3.0'
 
   s.add_development_dependency 'ffi', '~> 1.0' # For selenium-webdriver on Windows
   s.add_development_dependency 'irb'


### PR DESCRIPTION
Add required_ruby_version  because using `&.`
https://github.com/titusfortner/webdrivers/blob/v4.1.3/lib/webdrivers/chrome_finder.rb#L83

https://www.ruby-lang.org/en/news/2015/12/25/ruby-2-3-0-released/