### PR TITLE
Add /snap/bin to chromium locations

### DIFF
--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -66,7 +66,7 @@ module Webdrivers
       end
 
       def linux_location
-        directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /opt/google/chrome]
+        directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin /opt/google/chrome]
         files = %w[google-chrome chrome chromium chromium-browser]
 
         directories.each do |dir|


### PR DESCRIPTION
In Ubuntu Linux, chromium browser is provided by snap package.
It's binary is `/snap/bin/chromium`.

This PR adds the path to `Webdrivers::ChromeFinder.linux_location`.

For details, see [Chromium in Ubuntu – deb to snap transition](https://ubuntu.com/blog/chromium-in-ubuntu-deb-to-snap-transition) (ubuntu.com)