### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,7 @@ Metrics/BlockLength:
   Exclude:
     - 'spec/**/*'
     - 'lib/webdrivers/tasks/*.rake'
+    - 'webdrivers.gemspec'
 
 Metrics/ClassLength:
   Max: 116

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -14,6 +14,13 @@ Gem::Specification.new do |s|
   s.description = 'Run Selenium tests more easily with install and updates for all supported webdrivers.'
   s.licenses    = ['MIT']
 
+  s.metadata = {
+    'bug_tracker_uri' => 'https://github.com/titusfortner/webdrivers/issues',
+    'changelog_uri' => 'https://github.com/titusfortner/webdrivers/blob/master/CHANGELOG.md',
+    'documentation_uri' => "https://www.rubydoc.info/gems/webdrivers/#{Webdrivers::VERSION}",
+    'source_code_uri' => "https://github.com/titusfortner/webdrivers/tree/v#{Webdrivers::VERSION}"
+  }
+
   s.files         = `git ls-files`.split("\n")
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/webdrivers), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.