### PR TITLE
Use #gets rather than #read to read from pipe in System#call

### DIFF
--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -156,7 +156,7 @@ module Webdrivers
         cmd = arg ? [process, arg] : process # Windows provides powershell command (process) only, no args.
         Webdrivers.logger.debug "making System call: #{cmd}"
         p = IO.popen(cmd)
-        out = p.gets
+        out = p.read
         p.close
         raise "Failed to make system call: #{cmd}" unless $CHILD_STATUS.success?
 

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -156,7 +156,7 @@ module Webdrivers
         cmd = arg ? [process, arg] : process # Windows provides powershell command (process) only, no args.
         Webdrivers.logger.debug "making System call: #{cmd}"
         p = IO.popen(cmd)
-        out = p.read
+        out = p.gets
         p.close
         raise "Failed to make system call: #{cmd}" unless $CHILD_STATUS.success?
 


### PR DESCRIPTION
I'm seeing the problem mentioned in #168, whereby calls to both `Webdrivers::Chromedriver.browser_version` and `Webdrivers::ChromeFinder.version` block indefinitely. The enclosed patch solves these for me by only reading a single line from the pipe in `System.call`, as opposed to calling `#read`, which I assume blocks until EOF(?). It _looks_ like all of the current calling points are only expecting a single-line, but this may be breaking behaviour.

Tests all still pass, but I'm not able to test whether this works on Windows.

My environment, for posterity's sake:
```
$ cat /etc/lsb-release
DISTRIB_ID=Ubuntu
DISTRIB_RELEASE=20.04
DISTRIB_CODENAME=focal
DISTRIB_DESCRIPTION="Ubuntu 20.04 LTS"
$ snap list | grep chromium
chromium                 81.0.4044.138               1143  latest/stable    canonical*    -
$ ruby --version
ruby 2.6.5p114 (2019-10-01 revision 67812) [x86_64-linux]
```