### PR TITLE
Implement initial support for WSLv1

### DIFF
--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -80,7 +80,7 @@ module Webdrivers
       end
 
       def file_name
-        System.platform == 'win' ? 'chromedriver.exe' : 'chromedriver'
+        System.platform == 'win' || System.wsl? ? 'chromedriver.exe' : 'chromedriver'
       end
 
       def download_url
@@ -92,7 +92,7 @@ module Webdrivers
                     normalize_version(required_version)
                   end
 
-        file_name = System.platform == 'win' ? 'win32' : "#{System.platform}64"
+        file_name = System.platform == 'win' || System.wsl? ? 'win32' : "#{System.platform}64"
         url = "#{base_url}/#{version}/chromedriver_#{file_name}.zip"
         Webdrivers.logger.debug "chromedriver URL: #{url}"
         @download_url = url

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -148,6 +148,25 @@ module Webdrivers
         end
       end
 
+      # @return [TrueClass, FalseClass]
+      def wsl?
+        platform == 'linux' && File.open('/proc/version').read.include?('Microsoft')
+      end
+
+      # @param [String] path
+      # @return [String]
+      def to_win32_path(path)
+        return path if /[a-z]:\\/iu.match?(path)
+
+        call("wslpath -w '#{path}'").chomp
+      end
+
+      # @param [String] path
+      # @return [String]
+      def to_wsl_path(path)
+        call("wslpath -u '#{path}'").chomp
+      end
+
       def bitsize
         Selenium::WebDriver::Platform.bitsize
       end

--- a/spec/webdrivers/system_spec.rb
+++ b/spec/webdrivers/system_spec.rb
@@ -1,0 +1,73 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+wsl_proc_contents = [
+  'Linux version 4.4.0-18362-Microsoft',
+  '(Microsoft@Microsoft.com)',
+  '(gcc version 5.4.0 (GCC) )',
+  '#836-Microsoft',
+  'Mon May 05 16:04:00 PST 2020'
+].join ' '
+
+describe Webdrivers::System do
+  describe '#wsl?' do
+    context 'when the current platform is linux' do
+      before { allow(described_class).to receive(:platform).and_return 'linux' }
+
+      it 'checks /proc/version' do
+        allow(File).to receive(:open).with('/proc/version').and_return(StringIO.new(wsl_proc_contents))
+
+        expect(described_class.wsl?).to eq true
+      end
+    end
+
+    context 'when the current platform is mac' do
+      before { allow(described_class).to receive(:platform).and_return 'mac' }
+
+      it 'does not bother checking proc' do
+        allow(File).to receive(:open).and_call_original
+
+        expect(described_class.wsl?).to eq false
+
+        expect(File).not_to have_received(:open).with('/proc/version')
+      end
+    end
+  end
+
+  describe '#to_win32_path' do
+    before { allow(described_class).to receive(:call).and_return("C:\\path\\to\\folder\n") }
+
+    it 'uses wslpath' do
+      described_class.to_win32_path '/c/path/to/folder'
+
+      expect(described_class).to have_received(:call).with('wslpath -w \'/c/path/to/folder\'')
+    end
+
+    it 'removes the trailing newline' do
+      expect(described_class.to_win32_path('/c/path/to/folder')).not_to end_with('\n')
+    end
+
+    context 'when the path is already in Windows format' do
+      it 'returns early' do
+        expect(described_class.to_win32_path('D:\\')).to eq 'D:\\'
+
+        expect(described_class).not_to have_received(:call)
+      end
+    end
+  end
+
+  describe '#to_wsl_path' do
+    before { allow(described_class).to receive(:call).and_return("/c/path/to/folder\n") }
+
+    it 'uses wslpath' do
+      described_class.to_wsl_path 'C:\\path\\to\\folder'
+
+      expect(described_class).to have_received(:call).with('wslpath -u \'C:\\path\\to\\folder\'')
+    end
+
+    it 'removes the trailing newline' do
+      expect(described_class.to_wsl_path('/c/path/to/folder')).not_to end_with('\n')
+    end
+  end
+end


### PR DESCRIPTION
This implementation is working for me locally without any edge cases, so wanted to open a PR for initial feedback on the structure.

I found during my implementing that it's fine for `chromedriver` to be called `chromedriver.exe`, which meant I didn't need to add any extra logic around extracting the file from the zip & then knowing to rename it.

I've not looked into the tests yet: unfortunately it's not really possible to write tests for WSL right now, as enabling WSL requires a restart which CIs & containers either don't support or crash on, but if you're ok with mocking/spying I can write some tests to make sure the right methods are called (which is how I've done it in other libraries).

closes #170 