### PR TITLE
Support using new powershell if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,14 @@ The logging level can be configured for debugging purpose:
 Webdrivers.logger.level = :DEBUG
 ```
 
+### WSLv1 support
+
+While WSLv1 is not designed to run headful applications like Chrome, it can run exes; as such when found to be running
+in WSL, `webdrivers` will use the Windows `chromedriver.exe`.
+
+It's recommended that you install the new PowerShell (PS7) to avoid [a known issue](https://github.com/microsoft/terminal/issues/367) 
+with the console font being changed when calling the old PowerShell (PS5).
+
 ### Browser Specific Notes
 
 #### Chrome/Chromium

--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -104,6 +104,8 @@ module Webdrivers
       end
 
       def win_version(location)
+        System.call("pswh.exe -command \"(Get-ItemProperty '#{location}').VersionInfo.ProductVersion\"")&.strip
+      rescue StandardError
         System.call("powershell.exe \"(Get-ItemProperty '#{location}').VersionInfo.ProductVersion\"")&.strip
       end
 


### PR DESCRIPTION
It seems that `tmux` does not always prevent the console from being made weird 😬

There's a bit of a spider web of github issues, but the main takeaway is that while MS would love to fix it, it's very unlikely they'll be able to without breaking a lot of other things, and ideally just use the new powershell.

I've included a link to [one of the issues](https://github.com/microsoft/terminal/issues/367) that serve as an entry into the web for those wanting more details :)

You can reproduce the underlying issue by just running `powershell.exe | true` on WSL.