### PR TITLE
Drop `git ls-files` in gemspec

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
 require:
   - rubocop-rspec
   - rubocop-performance
+  - rubocop-packaging
 
 Layout/SpaceInsideHashLiteralBraces:
   EnforcedStyle: no_space

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -3,6 +3,7 @@
 lib = File.expand_path('lib', __dir__)
 $LOAD_PATH.unshift lib unless $LOAD_PATH.include?(lib)
 require 'webdrivers/version'
+require 'rake/file_list'
 
 Gem::Specification.new do |s|
   s.name        = 'webdrivers'
@@ -22,7 +23,8 @@ Gem::Specification.new do |s|
     'source_code_uri' => "https://github.com/titusfortner/webdrivers/tree/v#{Webdrivers::VERSION}"
   }
 
-  s.files         = Dir['CHANGELOG.md', 'lib/**/*', 'LICENSE.txt', 'README.md']
+  s.files         = Rake::FileList['CHANGELOG.md', 'lib/**/*', 'LICENSE.txt', \
+                                   'README.md'].exclude(*File.read('.gitignore').split)
   s.test_files    = Dir['spec/**/*'].reject { |f| File.directory?(f) }
   s.executables   = []
   s.require_paths = ['lib']

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -22,8 +22,8 @@ Gem::Specification.new do |s|
     'source_code_uri' => "https://github.com/titusfortner/webdrivers/tree/v#{Webdrivers::VERSION}"
   }
 
-  s.files         = `git ls-files`.split("\n")
-  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
+  s.files         = Dir['CHANGELOG.md', 'lib/**/*', 'LICENSE.txt', 'README.md']
+  s.test_files    = Dir['spec/**/*'].reject { |f| File.directory?(f) }
   s.executables   = []
   s.require_paths = ['lib']
 
@@ -31,6 +31,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake', '~> 12.0'
   s.add_development_dependency 'rspec', '~> 3.0'
   s.add_development_dependency 'rubocop', '~>0.89'
+  s.add_development_dependency 'rubocop-packaging', '~>0.2.0'
   s.add_development_dependency 'rubocop-performance'
   s.add_development_dependency 'rubocop-rspec', '~>1.42'
   s.add_development_dependency 'simplecov', '~>0.16'


### PR DESCRIPTION
Hi @kapoorlakshya (again! :smile:),

Thanks for working on this! :heart: 
However, while maintaining this in Debian, we found that this library relies on `git` to list the files which could be done via pure Ruby alternative -- which is what this PR does.

As an addition, this PR makes sure that this gem only ships the required files to the end-users and not other things which are not needed by them! :rocket: 

Also, added rubocop-packaging as a development_dependency which will ensure the best practices.
Here's what it showed us:

```
➜  webdrivers git:(master) ✗ rubocop --only Packaging

Inspecting 32 files
...............................C

Offenses:

webdrivers.gemspec:25:21: C: Packaging/GemspecGit: Avoid using git to produce lists of files.
Downstreams often need to build your package in an environment that does not have git (on purpose).
Use some pure Ruby alternative, like Dir or Dir.glob.
  s.files         = `git ls-files`.split("\n")
                    ^^^^^^^^^^^^^^
webdrivers.gemspec:26:21: C: Packaging/GemspecGit: Avoid using git to produce lists of files.
Downstreams often need to build your package in an environment that does not have git (on purpose).
Use some pure Ruby alternative, like Dir or Dir.glob.
  s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

32 files inspected, 2 offenses detected
```
And this PR fixes the same, which helps us in shipping this in Debian! :tada: 
Hope this would make sense and you'll be open to this change :100: 

Signed-off-by: Utkarsh Gupta <<utkarsh@debian.org>>