### PR TITLE
Fix typo in powershell executable name (Powershell 7)

### DIFF
--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -104,7 +104,7 @@ module Webdrivers
       end
 
       def win_version(location)
-        System.call("pswh.exe -command \"(Get-ItemProperty '#{location}').VersionInfo.ProductVersion\"")&.strip
+        System.call("pwsh.exe -command \"(Get-ItemProperty '#{location}').VersionInfo.ProductVersion\"")&.strip
       rescue StandardError
         System.call("powershell.exe \"(Get-ItemProperty '#{location}').VersionInfo.ProductVersion\"")&.strip
       end


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/powershell/scripting/install/migrating-from-windows-powershell-51-to-powershell-7?view=powershell-7.1