### PR TITLE
Make WSL detection more generic

### DIFF
--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -150,7 +150,7 @@ module Webdrivers
 
       # @return [TrueClass, FalseClass]
       def wsl?
-        platform == 'linux' && File.open('/proc/version').read.include?('Microsoft')
+        platform == 'linux' && File.open('/proc/version').read.downcase.include?('microsoft')
       end
 
       # @param [String] path


### PR DESCRIPTION
On WSL2, the contents of `/proc/version` seem to have changed slightly, the command currently in webdrivers currently returns false:

```ruby
irb(main):001:0> File.open('/proc/version').read.include?('Microsoft')
=> false
irb(main):002:0> File.open('/proc/version').read.downcase.include?('microsoft')
=> true
```

Full contents for completeness:

```ruby
irb(main):003:0> File.open('/proc/version').read
=> "Linux version 4.19.104-microsoft-standard (oe-user@oe-host) (gcc version 8.2.0 (GCC)) #1 SMP Wed Feb 19 06:37:35 UTC 2020\n"
```

Unfortunately this does not seem to fix all of the issues, although I am unsure if the rest of the issues are in the webdrivers gem or not. I am still receiving a `Selenium::WebDriver::Error::WebDriverError: unable to connect to chromedriver 127.0.0.1:9515` error when trying to run on WSL2 with a pretty barebones Rails system test setup.