### PR TITLE
Add support for Apple M1 architecture (chromedriver)

### DIFF
--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -87,6 +87,14 @@ module Webdrivers
         System.platform == 'win' || System.wsl? ? 'chromedriver.exe' : 'chromedriver'
       end
 
+      def apple_m1_cpu?
+        RUBY_PLATFORM.include?('arm64-darwin')
+      end
+
+      def apple_m1_compatible?(version)
+        version >= normalize_version('87.0.4280.88')
+      end
+
       def download_url
         return @download_url if @download_url
 
@@ -96,7 +104,9 @@ module Webdrivers
                     normalize_version(required_version)
                   end
 
-        file_name = System.platform == 'win' || System.wsl? ? 'win32' : "#{System.platform}64"
+        archi = apple_m1_cpu? && apple_m1_compatible?(version) ? '_m1' : ''
+
+        file_name = System.platform == 'win' || System.wsl? ? 'win32' : "#{System.platform}64#{archi}"
         url = "#{base_url}/#{version}/chromedriver_#{file_name}.zip"
         Webdrivers.logger.debug "chromedriver URL: #{url}"
         @download_url = url

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -87,12 +87,8 @@ module Webdrivers
         System.platform == 'win' || System.wsl? ? 'chromedriver.exe' : 'chromedriver'
       end
 
-      def apple_m1_cpu?
-        RUBY_PLATFORM.include?('arm64-darwin')
-      end
-
       def apple_m1_compatible?(version)
-        version >= normalize_version('87.0.4280.88')
+        RUBY_PLATFORM.include?('arm64-darwin') && version >= normalize_version('87.0.4280.88')
       end
 
       def download_url
@@ -104,9 +100,9 @@ module Webdrivers
                     normalize_version(required_version)
                   end
 
-        archi = apple_m1_cpu? && apple_m1_compatible?(version) ? '_m1' : ''
+        apple_arch = apple_m1_compatible?(version) ? '_m1' : ''
 
-        file_name = System.platform == 'win' || System.wsl? ? 'win32' : "#{System.platform}64#{archi}"
+        file_name = System.platform == 'win' || System.wsl? ? 'win32' : "#{System.platform}64#{apple_arch}"
         url = "#{base_url}/#{version}/chromedriver_#{file_name}.zip"
         Webdrivers.logger.debug "chromedriver URL: #{url}"
         @download_url = url


### PR DESCRIPTION
Fixes #191

I hope it's the correct approach.

It's still compatible with Chromedriver versions lower than `87.0.4280.88` but it will then fallback to the Intel version of Chrome.