### PR TITLE
Improve format of README usage section

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ Works on macOS, Linux, Windows, and Windows Subsystem for Linux (WSL) v1.
 
 In your Gemfile:
 
-`gem 'webdrivers', '~> 4.0', require: false`
+```ruby
+gem 'webdrivers', '~> 4.0', require: false
+```
 
 In your project:
 


### PR DESCRIPTION
Now the section of Gemfile is syntax-hightlighted as Ruby.