### PR TITLE
Adds option to use chrome on Linux when running with WSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ in WSL, `webdrivers` will use the Windows `chromedriver.exe`.
 It's recommended that you install the new PowerShell (PS7) to avoid [a known issue](https://github.com/microsoft/terminal/issues/367) 
 with the console font being changed when calling the old PowerShell (PS5).
 
+### WSLv2 support
+
+You can use chrome headless on WSLv2. Install chrome on the WSL Linux and set `WD_USE_WINDOWS=0` to disable WSL detection, this will detect the system as Linux and use the chrome binary on Linux.
 ### Browser Specific Notes
 
 #### Chrome/Chromium

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -151,7 +151,7 @@ module Webdrivers
       # @return [TrueClass, FalseClass]
       def wsl?
         return false if ENV['WD_USE_WINDOWS'] == '0'
-         
+
         platform == 'linux' && File.open('/proc/version').read.downcase.include?('microsoft')
       end
 

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -150,6 +150,8 @@ module Webdrivers
 
       # @return [TrueClass, FalseClass]
       def wsl?
+        return false if ENV['WD_USE_WINDOWS'] == '0'
+         
         platform == 'linux' && File.open('/proc/version').read.downcase.include?('microsoft')
       end
 

--- a/spec/webdrivers/chrome_finder_spec.rb
+++ b/spec/webdrivers/chrome_finder_spec.rb
@@ -22,8 +22,9 @@ describe Webdrivers::ChromeFinder do
     end
   end
 
-  it "uses ENV['WD_CHROME_PATH'] when it is defined" do
+  it "uses ENV['WD_CHROME_PATH'] when it is defined" do        
     allow(ENV).to receive(:[]).with('WD_CHROME_PATH').and_return(chrome_finder.location)
+    allow(ENV).to receive(:[]).with('WD_USE_WINDOWS').and_return(nil)
     locations = %i[win_location mac_location linux_location]
     allow(chrome_finder).to receive_messages(locations)
 
@@ -33,7 +34,8 @@ describe Webdrivers::ChromeFinder do
 
   it 'uses Selenium::WebDriver::Chrome.path over WD_CHROME_PATH' do
     Selenium::WebDriver::Chrome.path = chrome_finder.location
-    allow(ENV).to receive(:[]).with('WD_CHROME_PATH').and_return('my_wd_chrome_path')
+    allow(ENV).to receive(:[]).with('WD_USE_WINDOWS').and_return(nil)
+    allow(ENV).to receive(:[]).with('WD_CHROME_PATH').and_return('my_wd_chrome_path')    
     expect(chrome_finder.version).not_to be_nil
     expect(ENV).not_to have_received(:[]).with('WD_CHROME_PATH')
   end

--- a/spec/webdrivers/system_spec.rb
+++ b/spec/webdrivers/system_spec.rb
@@ -23,10 +23,10 @@ describe Webdrivers::System do
     end
 
     context 'when the current platform is linux and WD_USE_WINDOWS is set to 0' do
-      before { ENV['WD_USE_WINDOWS'] = '0' }
-
-      after { ENV.delete('WD_USE_WINDOWS') }
-
+      before do
+        allow(ENV).to receive(:[]).with('WD_USE_WINDOWS').and_return('0')
+      end
+      
       it { expect(described_class.wsl?).to eq false }
     end
 

--- a/spec/webdrivers/system_spec.rb
+++ b/spec/webdrivers/system_spec.rb
@@ -22,10 +22,19 @@ describe Webdrivers::System do
       end
     end
 
+    context 'when the current platform is linux and WD_USE_WINDOWS is set to 0' do
+      before { ENV['WD_USE_WINDOWS'] = '0' }
+
+      after { ENV.delete('WD_USE_WINDOWS') }
+
+      it { expect(described_class.wsl?).to eq false }
+    end
+
     context 'when the current platform is mac' do
       before { allow(described_class).to receive(:platform).and_return 'mac' }
 
       it 'does not bother checking proc' do
+        puts ENV['WD_USE_WINDOWS']
         allow(File).to receive(:open).and_call_original
 
         expect(described_class.wsl?).to eq false


### PR DESCRIPTION
As discussed in #192, after v4.4.2 it is impossible to use Chrome on Linux when running in WSL as the system is detected as WSL and tries to always use the Chrome on Windows.

I don't know if this is the best solution to this, but i'd like to have the option to run Chrome on Linux and this solves my issue. 

I'm not sure about the name of the env var and if this is clear enough, I'll be happy to accept suggestions.