### PR TITLE
Does not use Chrome on Windows on WSLv2

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,6 +204,12 @@ in WSL, `webdrivers` will use the Windows `chromedriver.exe`.
 It's recommended that you install the new PowerShell (PS7) to avoid [a known issue](https://github.com/microsoft/terminal/issues/367) 
 with the console font being changed when calling the old PowerShell (PS5).
 
+### WSLv2 support
+
+Webdrivers will detect WSLv2 as running on Linux.
+
+WSLv2 doesn't support connecting to host ports out of the box, so it isn't possible to connect to Chromedriver on Windows without extra configurations, see: https://github.com/microsoft/WSL/issues/4619. The simplest way to use Chromedriver with WSLv2 is to run Chrome headless on Linux.
+
 ### Browser Specific Notes
 
 #### Chrome/Chromium

--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -88,7 +88,7 @@ module Webdrivers
       end
 
       def linux_location
-        return wsl_location if System.wslv1?
+        return wsl_location if System.wsl_v1?
 
         directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin /opt/google/chrome]
         files = %w[google-chrome chrome chromium chromium-browser]
@@ -114,7 +114,7 @@ module Webdrivers
       end
 
       def linux_version(location)
-        return wsl_version(location) if System.wslv1?
+        return wsl_version(location) if System.wsl_v1?
 
         System.call(location, '--product-version')&.strip
       end

--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -88,7 +88,7 @@ module Webdrivers
       end
 
       def linux_location
-        return wsl_location if System.wsl?
+        return wsl_location if System.wslv1?
 
         directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin /opt/google/chrome]
         files = %w[google-chrome chrome chromium chromium-browser]
@@ -114,7 +114,7 @@ module Webdrivers
       end
 
       def linux_version(location)
-        return wsl_version(location) if System.wsl?
+        return wsl_version(location) if System.wslv1?
 
         System.call(location, '--product-version')&.strip
       end

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -84,7 +84,7 @@ module Webdrivers
       end
 
       def file_name
-        System.platform == 'win' || System.wsl? ? 'chromedriver.exe' : 'chromedriver'
+        System.platform == 'win' || System.wslv1? ? 'chromedriver.exe' : 'chromedriver'
       end
 
       def download_url
@@ -96,7 +96,7 @@ module Webdrivers
                     normalize_version(required_version)
                   end
 
-        file_name = System.platform == 'win' || System.wsl? ? 'win32' : "#{System.platform}64"
+        file_name = System.platform == 'win' || System.wslv1? ? 'win32' : "#{System.platform}64"
         url = "#{base_url}/#{version}/chromedriver_#{file_name}.zip"
         Webdrivers.logger.debug "chromedriver URL: #{url}"
         @download_url = url

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -84,7 +84,7 @@ module Webdrivers
       end
 
       def file_name
-        System.platform == 'win' || System.wslv1? ? 'chromedriver.exe' : 'chromedriver'
+        System.platform == 'win' || System.wsl_v1? ? 'chromedriver.exe' : 'chromedriver'
       end
 
       def download_url
@@ -96,7 +96,7 @@ module Webdrivers
                     normalize_version(required_version)
                   end
 
-        file_name = System.platform == 'win' || System.wslv1? ? 'win32' : "#{System.platform}64"
+        file_name = System.platform == 'win' || System.wsl_v1? ? 'win32' : "#{System.platform}64"
         url = "#{base_url}/#{version}/chromedriver_#{file_name}.zip"
         Webdrivers.logger.debug "chromedriver URL: #{url}"
         @download_url = url

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -149,8 +149,8 @@ module Webdrivers
       end
 
       # @return [TrueClass, FalseClass]
-      def wsl?
-        platform == 'linux' && File.open('/proc/version').read.downcase.include?('microsoft')
+      def wslv1?
+        platform == 'linux' && File.open('/proc/version').read.include?('Microsoft')
       end
 
       # @param [String] path

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -149,7 +149,7 @@ module Webdrivers
       end
 
       # @return [TrueClass, FalseClass]
-      def wslv1?
+      def wsl_v1?
         platform == 'linux' && File.open('/proc/version').read.include?('Microsoft')
       end
 

--- a/spec/webdrivers/chrome_finder_spec.rb
+++ b/spec/webdrivers/chrome_finder_spec.rb
@@ -52,7 +52,7 @@ describe Webdrivers::ChromeFinder do
     before do
       skip "The current platform cannot be WSL, as it's not Linux" unless Selenium::WebDriver::Platform.linux?
 
-      allow(Webdrivers::System).to receive(:wsl?).and_return(true)
+      allow(Webdrivers::System).to receive(:wslv1?).and_return(true)
       allow(Webdrivers::System).to receive(:to_wsl_path).and_return('')
       allow(Webdrivers::System).to receive(:to_win32_path).and_return('')
     end

--- a/spec/webdrivers/chrome_finder_spec.rb
+++ b/spec/webdrivers/chrome_finder_spec.rb
@@ -52,7 +52,7 @@ describe Webdrivers::ChromeFinder do
     before do
       skip "The current platform cannot be WSL, as it's not Linux" unless Selenium::WebDriver::Platform.linux?
 
-      allow(Webdrivers::System).to receive(:wslv1?).and_return(true)
+      allow(Webdrivers::System).to receive(:wsl_v1?).and_return(true)
       allow(Webdrivers::System).to receive(:to_wsl_path).and_return('')
       allow(Webdrivers::System).to receive(:to_win32_path).and_return('')
     end

--- a/spec/webdrivers/system_spec.rb
+++ b/spec/webdrivers/system_spec.rb
@@ -3,8 +3,8 @@
 require 'spec_helper'
 
 describe Webdrivers::System do
-  describe '#wslv1?' do
-    subject(:wslv1) { described_class.wslv1? }
+  describe '#wsl_v1?' do
+    subject { described_class.wsl_v1? }
 
     before do
       allow(described_class).to receive(:platform).and_return(platform)

--- a/spec/webdrivers/system_spec.rb
+++ b/spec/webdrivers/system_spec.rb
@@ -2,36 +2,42 @@
 
 require 'spec_helper'
 
-wsl_proc_contents = [
-  'Linux version 4.4.0-18362-Microsoft',
-  '(Microsoft@Microsoft.com)',
-  '(gcc version 5.4.0 (GCC) )',
-  '#836-Microsoft',
-  'Mon May 05 16:04:00 PST 2020'
-].join ' '
-
 describe Webdrivers::System do
-  describe '#wsl?' do
-    context 'when the current platform is linux' do
-      before { allow(described_class).to receive(:platform).and_return 'linux' }
+  describe '#wslv1?' do
+    subject(:wslv1) { described_class.wslv1? }
 
-      it 'checks /proc/version' do
-        allow(File).to receive(:open).with('/proc/version').and_return(StringIO.new(wsl_proc_contents))
+    before do
+      allow(described_class).to receive(:platform).and_return(platform)
+      allow(File).to receive(:open).with('/proc/version').and_return(StringIO.new(wsl_proc_version_contents))
+    end
 
-        expect(described_class.wsl?).to eq true
+    let(:platform) { 'linux' }
+    let(:wsl_proc_version_contents) { '' }
+
+    context 'when the current platform is linux and WSL version is 1' do
+      let(:wsl_proc_version_contents) do
+        'Linux version 4.4.0-18362-Microsoft'\
+        '(Microsoft@Microsoft.com) (gcc version 5.4.0 (GCC) )'\
+        '#836-Microsoft Mon May 05 16:04:00 PST 2020'
       end
+
+      it { is_expected.to eq true }
+    end
+
+    context 'when the current platform is linux and WSL version is 2' do
+      let(:wsl_proc_version_contents) do
+        'Linux version 4.19.84-microsoft-standard '\
+        '(oe-user@oe-host) (gcc version 8.2.0 (GCC)) '\
+        '#1 SMP Wed Nov 13 11:44:37 UTC 2019'
+      end
+
+      it { is_expected.to eq false }
     end
 
     context 'when the current platform is mac' do
-      before { allow(described_class).to receive(:platform).and_return 'mac' }
+      let(:platform) { 'mac' }
 
-      it 'does not bother checking proc' do
-        allow(File).to receive(:open).and_call_original
-
-        expect(described_class.wsl?).to eq false
-
-        expect(File).not_to have_received(:open).with('/proc/version')
-      end
+      it { is_expected.to eq false }
     end
   end
 


### PR DESCRIPTION
Fixes #192 

This PR https://github.com/titusfortner/webdrivers/pull/187 changed WSL detection to detect both WSLv1 and WSLv2 as running in WSL and use Chrome on Windows for both versions. But it doesn't work on WSLv2 out of the box.

WSL2 networking is different from WSL1 and you can't connect from the WSL2 Linux on Chromedriver running on Windows using `127.0.0.1:9515`, see: https://github.com/microsoft/WSL/issues/4619

This PR changes the wsl detection to be explicity about v1 and only uses Chromedriver on Windows if it is WSLv1, as it doesn't work on WSLv2.