### PR TITLE
rename Edge classes to support Selenium 4 beta

### DIFF
--- a/gemfiles/Gemfile.edge
+++ b/gemfiles/Gemfile.edge
@@ -4,4 +4,4 @@ source 'https://rubygems.org'
 
 # Specify your gem's dependencies in webdrivers.gemspec
 gemspec path: '..'
-gem 'selenium-webdriver', github: 'seleniumhq/selenium', branch: 'trunk', glob: 'rb/*.gemspec'
+gem 'selenium-webdriver', '>= 4.0.0.beta1'

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -24,15 +24,15 @@ module Webdrivers
       private
 
       def user_defined_location
-        if Selenium::WebDriver::EdgeChrome.path
-          Webdrivers.logger.debug "Selenium::WebDriver::EdgeChrome.path: #{Selenium::WebDriver::EdgeChrome.path}"
-          return Selenium::WebDriver::EdgeChrome.path
+        if Selenium::WebDriver::Edge.path
+          Webdrivers.logger.debug "Selenium::WebDriver::Edge.path: #{Selenium::WebDriver::Edge.path}"
+          return Selenium::WebDriver::Edge.path
         end
 
-        return if ENV['WD_EDGE_CHROME_PATH'].nil?
+        return if ENV['WD_EDGE_PATH'].nil?
 
-        Webdrivers.logger.debug "WD_EDGE_CHROME_PATH: #{ENV['WD_EDGE_CHROME_PATH']}"
-        ENV['WD_EDGE_CHROME_PATH']
+        Webdrivers.logger.debug "WD_EDGE_PATH: #{ENV['WD_EDGE_PATH']}"
+        ENV['WD_EDGE_PATH']
       end
 
       def win_location

--- a/lib/webdrivers/edgedriver.rb
+++ b/lib/webdrivers/edgedriver.rb
@@ -111,19 +111,4 @@ module Webdrivers
   end
 end
 
-if defined? Selenium::WebDriver::EdgeChrome
-  if ::Selenium::WebDriver::Service.respond_to? :driver_path=
-    ::Selenium::WebDriver::EdgeChrome::Service.driver_path = proc { ::Webdrivers::Edgedriver.update }
-  else
-    # v3.141.0 and lower
-    module Selenium
-      module WebDriver
-        module EdgeChrome
-          def self.driver_path
-            @driver_path ||= Webdrivers::Edgedriver.update
-          end
-        end
-      end
-    end
-  end
-end
+::Selenium::WebDriver::Edge::Service.driver_path = proc { ::Webdrivers::Edgedriver.update }

--- a/spec/webdrivers/edge_finder_spec.rb
+++ b/spec/webdrivers/edge_finder_spec.rb
@@ -6,9 +6,7 @@ describe Webdrivers::EdgeFinder do
   let(:edge_finder) { described_class }
 
   before(:all) do # rubocop:disable RSpec/BeforeAfterAll
-    # Skip these tests if version of selenium-webdriver being tested with doesn't
-    # have Chromium based Edge support
-    unless defined?(Selenium::WebDriver::EdgeChrome)
+    if Selenium::WebDriver::VERSION[0].to_i < 4
       skip "The current selenium-webdriver doesn't include Chromium based Edge support"
     end
   end
@@ -20,8 +18,8 @@ describe Webdrivers::EdgeFinder do
   end
 
   context 'when the user provides a path to the Edge binary' do
-    it 'uses Selenium::WebDriver::EdgeChrome.path when it is defined' do
-      Selenium::WebDriver::EdgeChrome.path = edge_finder.location
+    it 'uses Selenium::WebDriver::Edge.path when it is defined' do
+      Selenium::WebDriver::Edge.path = edge_finder.location
       locations = %i[win_location mac_location linux_location]
       allow(edge_finder).to receive_messages(locations)
 
@@ -29,8 +27,8 @@ describe Webdrivers::EdgeFinder do
       locations.each { |loc| expect(edge_finder).not_to have_received(loc) }
     end
 
-    it "uses ENV['WD_EDGE_CHROME_PATH'] when it is defined" do
-      allow(ENV).to receive(:[]).with('WD_EDGE_CHROME_PATH').and_return(edge_finder.location)
+    it "uses ENV['WD_EDGE_PATH'] when it is defined" do
+      allow(ENV).to receive(:[]).with('WD_EDGE_PATH').and_return(edge_finder.location)
       locations = %i[win_location mac_location linux_location]
       allow(edge_finder).to receive_messages(locations)
 
@@ -38,11 +36,11 @@ describe Webdrivers::EdgeFinder do
       locations.each { |loc| expect(edge_finder).not_to have_received(loc) }
     end
 
-    it 'uses Selenium::WebDriver::EdgeChrome.path over WD_EDGE_CHROME_PATH' do
-      Selenium::WebDriver::EdgeChrome.path = edge_finder.location
-      allow(ENV).to receive(:[]).with('WD_EDGE_CHROME_PATH').and_return('my_wd_chrome_path')
+    it 'uses Selenium::WebDriver::Edge.path over WD_EDGE_PATH' do
+      Selenium::WebDriver::Edge.path = edge_finder.location
+      allow(ENV).to receive(:[]).with('WD_EDGE_PATH').and_return('my_wd_chrome_path')
       expect(edge_finder.version).not_to be_nil
-      expect(ENV).not_to have_received(:[]).with('WD_EDGE_CHROME_PATH')
+      expect(ENV).not_to have_received(:[]).with('WD_EDGE_PATH')
     end
   end
 

--- a/spec/webdrivers/edgedriver_spec.rb
+++ b/spec/webdrivers/edgedriver_spec.rb
@@ -6,9 +6,7 @@ describe Webdrivers::Edgedriver do
   let(:edgedriver) { described_class }
 
   before(:all) do # rubocop:disable RSpec/BeforeAfterAll
-    # Skip these tests if version of selenium-webdriver being tested with doesn't
-    # have Chromium based Edge support
-    unless defined?(Selenium::WebDriver::EdgeChrome)
+    if Selenium::WebDriver::VERSION[0].to_i < 4
       skip "The current selenium-webdriver doesn't include Chromium based Edge support"
     end
   end


### PR DESCRIPTION
In Selenium 3.142.7 we used `Edge` to refer to the old Edge HTML implementation.
When we switched to working on Selenium 4 we split them into `EdgeChrome` and `EdgeHtml`
For Selenium 4 beta, we've dropped support for Edge HTML entirely, so everything that was `EdgeChrome` is now just `Edge.`

The current test runs will be passing because the specs skip them incorrectly now. (take a look at skipped tests: https://github.com/titusfortner/webdrivers/runs/1990772141)

This PR renames `EdgeChrome` to `Edge`. 
The only people using this class have been using it with Selenium 4 alpha because it isn't supported at all in the latest production version of Selenium.

This code is not backward compatible with Selenium 4 alpha, but I think the correct response is for those people to update to using Selenium 4 beta rather than this gem giving warnings or upgrade paths. 

Any concerns?