### PR TITLE
Linux edge fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# master (Unreleased)
+* Allow `Edgedriver` to be maintained by Linux users
+
 # 4.6.1 (2021-08-19)
 * Fix bug in IEdriver caused by bad formatting in recent release
 

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -24,6 +24,8 @@ module Webdrivers
       private
 
       def user_defined_location
+        return unless defined? Selenium::WebDriver::Edge.path
+
         if Selenium::WebDriver::Edge.path
           Webdrivers.logger.debug "Selenium::WebDriver::Edge.path: #{Selenium::WebDriver::Edge.path}"
           return Selenium::WebDriver::Edge.path

--- a/lib/webdrivers/edge_finder.rb
+++ b/lib/webdrivers/edge_finder.rb
@@ -69,18 +69,16 @@ module Webdrivers
       end
 
       def linux_location
-        # directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin /opt/google/chrome]
-        # files = %w[microsoft-edge] # Based on Microsoft Edge 89.0.760.0 dev
-        #
-        # directories.each do |dir|
-        #   files.each do |file|
-        #     option = "#{dir}/#{file}"
-        #     return option if File.exist?(option)
-        #   end
-        # end
-        #
-        # nil
-        raise 'Default location not yet known'
+        directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin /opt/google/chrome]
+        files = %w[microsoft-edge] # This is correct for beta versions as well as normalized ones
+
+        directories.each do |dir|
+          files.each do |file|
+            option = "#{dir}/#{file}"
+            return option if File.exist?(option)
+          end
+        end
+        nil
       end
 
       def win_version(location)

--- a/lib/webdrivers/edgedriver.rb
+++ b/lib/webdrivers/edgedriver.rb
@@ -76,15 +76,15 @@ module Webdrivers
         false
       end
 
-      # def linux_compatible?(driver_version)
-      #   System.platform == 'linux' && driver_version >= normalize_version('89.0.731.0')
-      # end
+      def linux_compatible?(driver_version)
+        System.platform == 'linux' && driver_version >= normalize_version('89.0.731.0')
+      end
 
       def driver_filename(driver_version)
         if System.platform == 'win' || System.wsl_v1?
           "win#{System.bitsize}" # 32 or 64-bit
-        # elsif linux_compatible?(driver_version)
-        #   'linux64'
+        elsif linux_compatible?(driver_version)
+          'linux64'
         elsif System.platform == 'mac'
           # Determine M1 or Intel architecture
           apple_arch = apple_m1_compatible?(driver_version) ? 'arm' : 'mac'


### PR DESCRIPTION
* Allow Linux Edge to be automatically detected and interrogated for browser version
* Allow msedgedriver to be automatically detected and downloaded on Linux
* Prevent NME caused by selenium versions not being fully updated