### PR TITLE
Allow `selenium-webdriver` 4.0.0

### DIFF
--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -38,5 +38,5 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'rubyzip', '>= 1.3.0'
-  s.add_runtime_dependency 'selenium-webdriver', '>= 3.0', '< 4.0'
+  s.add_runtime_dependency 'selenium-webdriver', '>= 3.0', '< 5.0'
 end


### PR DESCRIPTION
This pull request resolves the Rails issue https://github.com/rails/rails/issues/43455

Since `selenium-webdriver` 4.0.0 has been released, webdriver 4.6 is not allowed
likely due to version limitation in `webdrivers.gemspec`.

* bundle install failure at Rails issue 43455
```ruby
$ bundle install
Warning: the running version of Bundler (2.2.22) is older than the version that created the lockfile (2.2.29). We suggest you to upgrade to the version that created the lockfile by running `gem install bundler:2.2.29`.
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies.........
Bundler could not find compatible versions for gem "selenium-webdriver":
  In Gemfile:
    selenium-webdriver (>= 4.0.0.alpha7)

    webdrivers was resolved to 4.6.0, which depends on
      selenium-webdriver (>= 3.0, < 4.0)

Could not find gem 'selenium-webdriver (>= 3.0, < 4.0)', which is required by gem 'webdrivers', in source at
`/home/yahonda/src/github.com/SeleniumHQ/selenium`.

Bundler could not find compatible versions for gem "webdrivers":
  In snapshot (Gemfile.lock):
    webdrivers (= 4.6.0)

  In Gemfile:
    webdrivers

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
$
```

Refer
https://rubygems.org/gems/selenium-webdriver/versions/4.0.0