### PR TITLE
Fix entry of v4.7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 * Add support for Selenium 4.x #218 (thanks yahonda )
 * Allow Edge on Linux
 * Update required Selenium > 3.141 because of a change in 4.6
-* Require Selenium 2.6+
+* Require Ruby 2.6+
 * Fix IE downloads with the change in location of assets
 
 # 4.6.1 (2021-08-19)


### PR DESCRIPTION
It seems that this is Ruby's version.
https://github.com/titusfortner/webdrivers/commit/c209cf82944afbb156b741f21adba7d499470967