### PR TITLE
Add `/opt/chromium.org/chromium` to Chromium locations for Linux

### DIFF
--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -90,7 +90,7 @@ module Webdrivers
       def linux_location
         return wsl_location if System.wsl_v1?
 
-        directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin /opt/google/chrome]
+        directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin /opt/google/chrome /opt/chromium.org/chromium]
         files = %w[google-chrome chrome chromium chromium-browser]
 
         directories.each do |dir|

--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -90,7 +90,17 @@ module Webdrivers
       def linux_location
         return wsl_location if System.wsl_v1?
 
-        directories = %w[/usr/local/sbin /usr/local/bin /usr/sbin /usr/bin /sbin /bin /snap/bin /opt/google/chrome /opt/chromium.org/chromium]
+        directories = %w[
+          /usr/local/sbin
+          /usr/local/bin
+          /usr/sbin
+          /usr/bin
+          /sbin
+          /bin
+          /snap/bin
+          /opt/google/chrome
+          /opt/chromium.org/chromium
+        ]
         files = %w[google-chrome chrome chromium chromium-browser]
 
         directories.each do |dir|


### PR DESCRIPTION
Something I noticed while working on #217

---

See: https://chromium-review.googlesource.com/c/chromium/src/+/1864462/5/chrome/test/chromedriver/chrome/chrome_finder.cc#65