### PR TITLE
Set `WEBDRIVERS=1` env var while running drivers

### DIFF
--- a/bin/drivers/chromedriver
+++ b/bin/drivers/chromedriver
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'webdrivers/chromedriver'
+
+ENV['WEBDRIVERS'] = '1'
+
+exec ::Webdrivers::Chromedriver.update

--- a/bin/drivers/edgedriver
+++ b/bin/drivers/edgedriver
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'webdrivers/edgedriver'
+
+ENV['WEBDRIVERS'] = '1'
+
+exec ::Webdrivers::Edgedriver.update

--- a/bin/drivers/geckodriver
+++ b/bin/drivers/geckodriver
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'webdrivers/geckodriver'
+
+ENV['WEBDRIVERS'] = '1'
+
+exec ::Webdrivers::Geckodriver.update

--- a/bin/drivers/iedriver
+++ b/bin/drivers/iedriver
@@ -1,0 +1,7 @@
+#!/usr/bin/env ruby
+
+require 'webdrivers/iedriver'
+
+ENV['WEBDRIVERS'] = '1'
+
+exec ::Webdrivers::IEdriver.update

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -146,4 +146,5 @@ module Webdrivers
   end
 end
 
-::Selenium::WebDriver::Chrome::Service.driver_path = proc { ::Webdrivers::Chromedriver.update }
+::Selenium::WebDriver::Chrome::Service.driver_path =
+  File.expand_path(File.join(__dir__, '../../bin/drivers/chromedriver'))

--- a/lib/webdrivers/edgedriver.rb
+++ b/lib/webdrivers/edgedriver.rb
@@ -101,4 +101,5 @@ module Webdrivers
   end
 end
 
-::Selenium::WebDriver::Edge::Service.driver_path = proc { ::Webdrivers::Edgedriver.update }
+::Selenium::WebDriver::Edge::Service.driver_path =
+  File.expand_path(File.join(__dir__, '../../bin/drivers/edgedriver'))

--- a/lib/webdrivers/geckodriver.rb
+++ b/lib/webdrivers/geckodriver.rb
@@ -60,4 +60,5 @@ module Webdrivers
   end
 end
 
-::Selenium::WebDriver::Firefox::Service.driver_path = proc { ::Webdrivers::Geckodriver.update }
+::Selenium::WebDriver::Firefox::Service.driver_path =
+  File.expand_path(File.join(__dir__, '../../bin/drivers/geckodriver'))

--- a/lib/webdrivers/iedriver.rb
+++ b/lib/webdrivers/iedriver.rb
@@ -65,4 +65,5 @@ module Webdrivers
   end
 end
 
-::Selenium::WebDriver::IE::Service.driver_path = proc { ::Webdrivers::IEdriver.update }
+::Selenium::WebDriver::IE::Service.driver_path =
+  File.expand_path(File.join(__dir__, '../../bin/drivers/iedriver'))

--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
     'source_code_uri' => "https://github.com/titusfortner/webdrivers/tree/v#{Webdrivers::VERSION}"
   }
 
-  s.files         = Dir['lib/**/*'] + %w[CHANGELOG.md LICENSE.txt README.md]
+  s.files         = Dir['lib/**/*'] + Dir['bin/drivers/**/*'] + %w[CHANGELOG.md LICENSE.txt README.md]
   s.test_files    = Dir['spec/**/*'].reject { |f| File.directory?(f) }
   s.executables   = []
   s.require_paths = ['lib']


### PR DESCRIPTION
See <https://github.com/titusfortner/webdrivers/issues/217#issuecomment-1019405659>

@kapoorlakshya I've tested this on my machine (Ubuntu 21.10), and I've confirmed that it does make the env var available to my script. If you would be able to test this on Windows (mainly to make sure that it didn't break anything, not so much that the env var is present), that would be amazing. Thank you!

The reason I added intermediate scripts in `bin/drivers/` is so that the env var is only set while that driver is actually running. I wanted to make sure that if a user launches a driver via this library and then launches a driver **not** via this library in the same script, it would have the env var set for the former but not the latter.

I totally understand if this is not an ideal change to this library. If not, my existing solution should work fine without the env var.