### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
       fail-fast: false
       matrix:
         os:  [ubuntu-18.04, macos-10.15, windows-2019]
-        ruby-version: [2.6, 2.7, 3.0, jruby]
+        ruby-version: [2.6, 2.7, '3.0', 3.1, jruby]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Ruby


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix