### PR TITLE
Download correct geckodriver version on MacOS M1

### DIFF
--- a/lib/webdrivers/geckodriver.rb
+++ b/lib/webdrivers/geckodriver.rb
@@ -51,7 +51,7 @@ module Webdrivers
         when 'linux'
           "linux#{System.bitsize}.tar.gz"
         when 'mac'
-          'macos.tar.gz'
+          System.apple_m1_architecture? ? 'macos-aarch64.tar.gz' : 'macos.tar.gz'
         when 'win'
           "win#{System.bitsize}.zip"
         end


### PR DESCRIPTION
There are two MacOS geckodriver versions. If the wrong one is downloaded, the user receives "Bad CPU type in executable". More info here: https://github.com/mozilla/geckodriver/issues/1984. This commit is checking if system architecture is Apple M1 to provide the correct `plataform_ext`.

I didn't find any tests to check `platform_ext` behavior, so I don't know if makes sense test these strings.