### PR TITLE
Improve error messages for debugging

### DIFF
--- a/lib/webdrivers/chrome_finder.rb
+++ b/lib/webdrivers/chrome_finder.rb
@@ -8,7 +8,7 @@ module Webdrivers
     class << self
       def version
         version = send("#{System.platform}_version", location)
-        raise VersionError, 'Failed to find Chrome version.' if version.nil? || version.empty?
+        raise VersionError, 'Failed to determine Chrome version.' if version.nil? || version.empty?
 
         Webdrivers.logger.debug "Browser version: #{version}"
         version[/\d+\.\d+\.\d+\.\d+/] # Google Chrome 73.0.3683.75 -> 73.0.3683.75
@@ -18,7 +18,7 @@ module Webdrivers
         chrome_bin = user_defined_location || send("#{System.platform}_location")
         return chrome_bin unless chrome_bin.nil?
 
-        raise BrowserNotFound, 'Failed to find Chrome binary.'
+        raise BrowserNotFound, 'Failed to determine Chrome binary location.'
       end
 
       private


### PR DESCRIPTION
This improves 2 error messages in ChromeFinder. Previously the messages
could imply that a file could not be found. It is more accurate to
say the binary location or version could not be determined (meaning there was no search for any file).