### PR TITLE
Fix circular require between webdrivers.rb and railtie.rb

### DIFF
--- a/lib/webdrivers/railtie.rb
+++ b/lib/webdrivers/railtie.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'webdrivers'
 require 'rails'
 
 module Webdrivers


### PR DESCRIPTION
`webdrivers.rb` requires `webdrivers/railtie.rb`,
https://github.com/titusfortner/webdrivers/blob/161d1bb67fbf74638dcc82068cc6c002a7caed89/lib/webdrivers.rb#L7

 and `webdrivers/railtie.rb` requires `webdrivers.rb`.
https://github.com/titusfortner/webdrivers/blob/161d1bb67fbf74638dcc82068cc6c002a7caed89/lib/webdrivers/railtie.rb#L3

This causes `warning: loading in progress, circular require considered harmful` warning from the Ruby interpreter.

Here's a minimum step to reproduce.

```sh
$ ruby -w -rrails -rwebdrivers -ep
<internal:.../rubygems/core_ext/kernel_require.rb>:148: warning: <internal:.../rubygems/core_ext/kernel_require.rb>:148: warning: loading in progress, circular require considered harmful - .../webdrivers-5.0.0/lib/webdrivers.rb
	from <internal:.../rubygems/core_ext/kernel_require.rb>:149:in  `require'
	from <internal:.../rubygems/core_ext/kernel_require.rb>:160:in  `rescue in require'
	from <internal:.../rubygems/core_ext/kernel_require.rb>:160:in  `require'
	from .../webdrivers-5.0.0/lib/webdrivers.rb:7:in  `<top (required)>'
	from <internal:.../rubygems/core_ext/kernel_require.rb>:96:in  `require'
	from <internal:.../rubygems/core_ext/kernel_require.rb>:96:in  `require'
	from .../webdrivers-5.0.0/lib/webdrivers/railtie.rb:3:in  `<top (required)>'
	from <internal:.../rubygems/core_ext/kernel_require.rb>:148:in  `require'
	from <internal:.../rubygems/core_ext/kernel_require.rb>:148:in  `require'
```

This patch fixes the warning by simply removing the `require` call in `webdrivers/railtie.rb`, since there won't be any actual use case where directly requiring `webdrivers/railtie.rb` without requiring `webdrivers.rb` (via bundler in most cases).