### PR TITLE
Fixes downloading on m1 macs from version 106.0.5249.61 onwards

### DIFF
--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -97,11 +97,11 @@ module Webdrivers
         false
       end
 
-      def apple_filename(driver_version)
+      def apple_m1_filename(driver_version)
         if apple_m1_compatible?(driver_version)
-          driver_version >= normalize_version('106.0.5249.61') ? 'mac_arm64' : 'mac64_m1'
+          driver_version >= normalize_version('106.0.5249.61') ? "mac_arm64" :  "mac64_m1"
         else
-          'mac64'
+          "mac64"
         end
       end
 
@@ -115,7 +115,7 @@ module Webdrivers
         elsif System.platform == 'linux'
           'linux64'
         elsif System.platform == 'mac'
-          apple_filename(driver_version)
+          apple_m1_filename(driver_version)
         else
           raise 'Failed to determine driver filename to download for your OS.'
         end

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -273,4 +273,42 @@ describe Webdrivers::Chromedriver do
       expect(chromedriver.browser_version).to be Gem::Version.new('72.0.0.0')
     end
   end
+
+  describe "private methods" do
+    describe "#direct_url" do
+      context "with mac platform" do
+
+        before do
+          allow(Webdrivers::System).to receive(:platform) { 'mac' }
+        end
+
+        context "when version is lower than 106.0.5249.61" do
+          it do
+            version_string = '71.0.3578.137'
+            version = Gem::Version.new(version_string)
+
+            expect(chromedriver.send(:direct_url, version)).to eq "#{chromedriver.base_url}/#{version_string}/chromedriver_mac64.zip"
+          end
+        end
+
+        context "when version is 106.0.5249.61" do
+          it do
+            version_string = '106.0.5249.61'
+            version = Gem::Version.new(version_string)
+
+            expect(chromedriver.send(:direct_url, version)).to eq "#{chromedriver.base_url}/#{version_string}/chromedriver_mac_arm64.zip"
+          end
+        end
+
+        context "when version is higher than 106.0.5249.61" do
+          it do
+            version_string = '106.0.5249.21'
+            version = Gem::Version.new(version_string)
+
+            expect(chromedriver.send(:direct_url, version)).to eq "#{chromedriver.base_url}/#{version_string}/chromedriver_mac64_m1.zip"
+          end
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Fix a similar Issue to #237

The download is failing again for the newer chrome version. From version 106.0.5249.61 onwards seems the filename is 'chromedriver_mac_arm64.zip'.

https://chromedriver.storage.googleapis.com/

Let me know if we should open an issue to this one.

I found testing this change a bit hard, so I went on testing a private method 💀 . I tested the method I perceive as the best candidate to be the public API of a new class.