### PR TITLE
Fixed Webdrivers::VersionError with chrome version greater than 115

### DIFF
--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -159,7 +159,7 @@ module Webdrivers
       end
 
       def stable_version
-        uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testinglast-known-good-versions.json')
+        uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testin/last-known-good-versions.json')
         res = Network.get(uri)
         JSON.parse(res, symbolize_names: true).dig(:channels, :Stable, :version)
       end

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -87,7 +87,6 @@ module Webdrivers
                 'https://chromedriver.storage.googleapis.com/index.html'
               end
 
-        p url
         msg = "#{msg} Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` "\
               "to a known chromedriver version: #{url}"
         Webdrivers.logger.debug msg
@@ -184,8 +183,6 @@ module Webdrivers
                                   .then { |res| JSON.parse(res, symbolize_names: true) }
                                   .then { |json| json.dig(:builds, :"#{driver_version}", :version) }
                                   .then { |version| version ? normalize_version(version) : nil }
-
-        p latest_patch_version
         raise NetworkError unless latest_patch_version
 
         latest_patch_version

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -114,7 +114,8 @@ module Webdrivers
       end
 
       def direct_url(driver_version)
-        direct_url_from_api(driver_version) || "#{base_url}/#{driver_version}/chromedriver_#{driver_filename(driver_version)}.zip"
+        direct_url_from_api(driver_version) ||
+          "#{base_url}/#{driver_version}/chromedriver_#{driver_filename(driver_version)}.zip"
       end
 
       def driver_filename(driver_version)
@@ -123,7 +124,11 @@ module Webdrivers
         elsif System.platform == 'linux'
           'linux64'
         elsif System.platform == 'mac'
-          driver_version >= normalize_version('115') ? apple_filename_for_api(driver_version) : apple_filename(driver_version)
+          if driver_version >= normalize_version('115')
+            apple_filename_for_api(driver_version)
+          else
+            apple_filename(driver_version)
+          end
         else
           raise 'Failed to determine driver filename to download for your OS.'
         end
@@ -163,14 +168,17 @@ module Webdrivers
       end
 
       def stable_version(driver_version)
-        return if  normalize_version('115') >= driver_version
+        return if driver_version < normalize_version('115')
+
         uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testing/last-known-good-versions.json')
         res = Network.get(uri)
-        normalize_version(JSON.parse(res, symbolize_names: true).dig(:channels, :Stable, :version))
+        result = normalize_version(JSON.parse(res, symbolize_names: true).dig(:channels, :Stable, :version))
+        driver_version > result ? nil : result
       end
 
       def direct_url_from_api(driver_version)
-        return if  normalize_version('115') >= driver_version
+        return if normalize_version(driver_version) < normalize_version('115')
+
         uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testing/last-known-good-versions-with-downloads.json')
         json = JSON.parse(Network.get(uri), symbolize_names: true).dig(:channels, :Stable, :downloads, :chromedriver)
         json.find { |e| e[:platform] == driver_filename(driver_version) }[:url]

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -155,7 +155,7 @@ module Webdrivers
       end
 
       def chrome_for_testing_base_url
-        'https://googlechromelabs-github-io.translate.goog'
+        'https://googlechromelabs.github.io'
       end
 
       def stable_version

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -163,14 +163,14 @@ module Webdrivers
       end
 
       def stable_version(driver_version)
-        return if  normalize_version('115') > driver_version
+        return if  normalize_version('115') >= driver_version
         uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testing/last-known-good-versions.json')
         res = Network.get(uri)
         normalize_version(JSON.parse(res, symbolize_names: true).dig(:channels, :Stable, :version))
       end
 
       def direct_url_from_api(driver_version)
-        return if  normalize_version('115') > driver_version
+        return if  normalize_version('115') >= driver_version
         uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testing/last-known-good-versions-with-downloads.json')
         json = JSON.parse(Network.get(uri), symbolize_names: true).dig(:channels, :Stable, :downloads, :chromedriver)
         json.find { |e| e[:platform] == driver_filename(driver_version) }[:url]

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -3,7 +3,6 @@
 require 'shellwords'
 require 'webdrivers/common'
 require 'webdrivers/chrome_finder'
-require 'json'
 
 module Webdrivers
   class Chromedriver < Common
@@ -156,17 +155,17 @@ module Webdrivers
       end
 
       def chrome_for_testing_base_url
-        'https://googlechromelabs-github-io.translate.goog/chrome-for-testing'
+        'https://googlechromelabs-github-io.translate.goog'
       end
 
       def stable_version
-        uri = URI.join(chrome_for_testing_base_url, 'last-known-good-versions.json')
+        uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testinglast-known-good-versions.json')
         res = Network.get(uri)
         JSON.parse(res, symbolize_names: true).dig(:channels, :Stable, :version)
       end
 
       def direct_url_for_over_115(driver_version)
-        uri = URI.join(chrome_for_testing_base_url, 'last-known-good-versions-with-downloads.json')
+        uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testing/last-known-good-versions-with-downloads.json')
         json = JSON.parse(Network.get(uri), symbolize_names: true).dig(:channels, :Stable, :downloads, :chrome)
         json.find { |e| e[:platform] == driver_filename(driver_version) }[:url]
       end

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -170,6 +170,7 @@ module Webdrivers
       end
 
       def direct_url_from_api(driver_version)
+        return if  normalize_version('115') > driver_version
         uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testing/last-known-good-versions-with-downloads.json')
         json = JSON.parse(Network.get(uri), symbolize_names: true).dig(:channels, :Stable, :downloads, :chromedriver)
         json.find { |e| e[:platform] == driver_filename(driver_version) }[:url]

--- a/lib/webdrivers/chromedriver.rb
+++ b/lib/webdrivers/chromedriver.rb
@@ -171,7 +171,7 @@ module Webdrivers
 
       def direct_url_from_api(driver_version)
         uri = URI.join(chrome_for_testing_base_url, '/chrome-for-testing/last-known-good-versions-with-downloads.json')
-        json = JSON.parse(Network.get(uri), symbolize_names: true).dig(:channels, :Stable, :downloads, :chrome)
+        json = JSON.parse(Network.get(uri), symbolize_names: true).dig(:channels, :Stable, :downloads, :chromedriver)
         json.find { |e| e[:platform] == driver_filename(driver_version) }[:url]
       end
     end

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -127,19 +127,24 @@ module Webdrivers
         Webdrivers.logger.debug "Decompressing #{filename}"
 
         Zip::File.open(filename) do |zip_file|
-          driver = zip_file.entries.find do |e|
-            if driver_name == 'chromedriver'
-              File.basename(e.name) == driver_name
-            else
-              zip_file.get_entry(driver_name)
-            end
-          end
-          f_path = File.join(Dir.pwd,  driver_name == 'chromedriver' ? File.basename(driver.name) : driver.name)
+          driver, f_path = driver_and_path(zip_file, driver_name)
           delete(f_path)
           FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))
           zip_file.extract(driver, f_path)
         end
         driver_name
+      end
+
+      def driver_and_path(zip_file, driver_name)
+        driver = zip_file.get_entry(driver_name)
+        f_path = File.join(Dir.pwd, driver.name)
+
+        [driver, f_path]
+      rescue Errno::ENOENT
+        driver = zip_file.entries.find { |e| File.basename(e.name) == driver_name }
+        f_path = File.join(Dir.pwd, File.basename(driver.name))
+
+        [driver, f_path]
       end
 
       def platform

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -127,8 +127,8 @@ module Webdrivers
         Webdrivers.logger.debug "Decompressing #{filename}"
 
         Zip::File.open(filename) do |zip_file|
-          driver = zip_file.get_entry(driver_name)
-          f_path = File.join(Dir.pwd, driver.name)
+          driver = zip_file.entries.find { |e| File.basename(e.name) == driver_name }
+          f_path = File.join(Dir.pwd, File.basename(driver.name))
           delete(f_path)
           FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))
           zip_file.extract(driver, f_path)

--- a/lib/webdrivers/system.rb
+++ b/lib/webdrivers/system.rb
@@ -127,8 +127,14 @@ module Webdrivers
         Webdrivers.logger.debug "Decompressing #{filename}"
 
         Zip::File.open(filename) do |zip_file|
-          driver = zip_file.entries.find { |e| File.basename(e.name) == driver_name }
-          f_path = File.join(Dir.pwd, File.basename(driver.name))
+          driver = zip_file.entries.find do |e|
+            if driver_name == 'chromedriver'
+              File.basename(e.name) == driver_name
+            else
+              zip_file.get_entry(driver_name)
+            end
+          end
+          f_path = File.join(Dir.pwd,  driver_name == 'chromedriver' ? File.basename(driver.name) : driver.name)
           delete(f_path)
           FileUtils.mkdir_p(File.dirname(f_path)) unless File.exist?(File.dirname(f_path))
           zip_file.extract(driver, f_path)

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -66,7 +66,7 @@ describe Webdrivers::Chromedriver do
         allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
         allow(chromedriver).to receive(:exists?).and_return(false)
 
-        msg = %r{Can not reach https://chromedriver.storage.googleapis.com}
+        msg = %r{Can not reach https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json}
         expect { chromedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
       end
     end
@@ -101,7 +101,7 @@ describe Webdrivers::Chromedriver do
       it 'raises ConnectionError if offline' do
         allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
 
-        msg = %r{Can not reach https://chromedriver.storage.googleapis.com/}
+        msg = %r{Can not reach https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json}
         expect { chromedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
       end
     end
@@ -223,11 +223,12 @@ describe Webdrivers::Chromedriver do
     it 'raises ConnectionError when offline' do
       allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
 
-      msg = %r{^Can not reach https://chromedriver.storage.googleapis.com}
+      msg = %r{^Can not reach https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json}
       expect { chromedriver.latest_version }.to raise_error(Webdrivers::ConnectionError, msg)
     end
 
     it 'creates cached file' do
+      allow(chromedriver).to receive(:stable_version).and_return(nil)
       allow(Webdrivers::Network).to receive(:get).and_return('71.0.3578.137')
 
       chromedriver.latest_version

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -168,6 +168,24 @@ describe Webdrivers::Chromedriver do
         chromedriver.update
         expect(Webdrivers::System).to have_received(:download).with(end_with('_mac64_m1.zip'), anything)
       end
+
+      it 'uses the correct chromedriver filename suffix for versions greater than 115 for Intel' do
+        allow(Webdrivers::System).to receive(:apple_m1_architecture?).and_return(false)
+        allow(chromedriver).to receive(:latest_version).and_return(Gem::Version.new('115.0.5790.102'))
+        chromedriver.required_version = nil
+
+        chromedriver.update
+        expect(Webdrivers::System).to have_received(:download).with(end_with('-mac-x64.zip'), anything)
+      end
+
+      it 'uses the correct chromedriver filename suffix for versions greater than 115 for Silicon' do
+        allow(Webdrivers::System).to receive(:apple_m1_architecture?).and_return(true)
+        allow(chromedriver).to receive(:latest_version).and_return(Gem::Version.new('115.0.5790.102'))
+        chromedriver.required_version = nil
+
+        chromedriver.update
+        expect(Webdrivers::System).to have_received(:download).with(end_with('-mac-arm64.zip'), anything)
+      end
     end
   end
 
@@ -266,9 +284,7 @@ describe Webdrivers::Chromedriver do
         {"channels":
           {"Stable":
             {
-              "channel": 'Stable',
               "version": '115.0.5790.102',
-              "revision": '1148114'
             }}}.to_json
       )
       uri = URI.join('https://googlechromelabs.github.io', 'chrome-for-testing/last-known-good-versions.json')

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -66,7 +66,7 @@ describe Webdrivers::Chromedriver do
         allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
         allow(chromedriver).to receive(:exists?).and_return(false)
 
-        msg = %r{Can not reach https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json}
+        msg = %r{Can not reach https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build.json}
         expect { chromedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
       end
     end
@@ -101,7 +101,7 @@ describe Webdrivers::Chromedriver do
       it 'raises ConnectionError if offline' do
         allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
 
-        msg = %r{Can not reach https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json}
+        msg = %r{Can not reach https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build.json}
         expect { chromedriver.update }.to raise_error(Webdrivers::ConnectionError, msg)
       end
     end
@@ -224,7 +224,7 @@ describe Webdrivers::Chromedriver do
       msg = 'Unable to find latest point release version for 999.0.0. '\
 'You appear to be using a non-production version of Chrome. '\
 'Please set `Webdrivers::Chromedriver.required_version = <desired driver version>` '\
-'to a known chromedriver version: https://chromedriver.storage.googleapis.com/index.html'
+'to a known chromedriver version: https://googlechromelabs.github.io/chrome-for-testing'
 
       expect { chromedriver.latest_version }.to raise_exception(Webdrivers::VersionError, msg)
     end
@@ -241,12 +241,12 @@ describe Webdrivers::Chromedriver do
     it 'raises ConnectionError when offline' do
       allow(Net::HTTP).to receive(:get_response).and_raise(SocketError)
 
-      msg = %r{^Can not reach https://googlechromelabs.github.io/chrome-for-testing/last-known-good-versions.json}
+      msg = %r{^Can not reach https://googlechromelabs.github.io/chrome-for-testing/latest-patch-versions-per-build.json}
       expect { chromedriver.latest_version }.to raise_error(Webdrivers::ConnectionError, msg)
     end
 
     it 'creates cached file' do
-      allow(chromedriver).to receive(:stable_version).and_return(nil)
+      allow(chromedriver).to receive(:latest_patch_version).and_return(nil)
       allow(Webdrivers::Network).to receive(:get).and_return('71.0.3578.137')
 
       chromedriver.latest_version
@@ -281,13 +281,9 @@ describe Webdrivers::Chromedriver do
     it 'call chrome_for_testing if the browser version is greater than 115' do
       allow(chromedriver).to receive(:browser_version).and_return Gem::Version.new('115.0.5790.102')
       allow(Webdrivers::Network).to receive(:get).and_return(
-        {"channels":
-          {"Stable":
-            {
-              "version": '115.0.5790.102',
-            }}}.to_json
+        {"builds": {'115.0.5790': {"version": '115.0.5790.102'}}}.to_json
       )
-      uri = URI.join('https://googlechromelabs.github.io', 'chrome-for-testing/last-known-good-versions.json')
+      uri = URI.join('https://googlechromelabs.github.io', '/chrome-for-testing/latest-patch-versions-per-build.json')
 
       expect(chromedriver.latest_version).to eq Gem::Version.new('115.0.5790.102')
       expect(Webdrivers::Network).to have_received(:get).with(uri)

--- a/spec/webdrivers/chromedriver_spec.rb
+++ b/spec/webdrivers/chromedriver_spec.rb
@@ -259,6 +259,23 @@ describe Webdrivers::Chromedriver do
       expect(Webdrivers::Network).to have_received(:get)
       expect(Webdrivers::System).to have_received(:valid_cache?)
     end
+
+    it 'call chrome_for_testing if the browser version is greater than 115' do
+      allow(chromedriver).to receive(:browser_version).and_return Gem::Version.new('115.0.5790.102')
+      allow(Webdrivers::Network).to receive(:get).and_return(
+        {"channels":
+          {"Stable":
+            {
+              "channel": 'Stable',
+              "version": '115.0.5790.102',
+              "revision": '1148114'
+            }}}.to_json
+      )
+      uri = URI.join('https://googlechromelabs.github.io', 'chrome-for-testing/last-known-good-versions.json')
+
+      expect(chromedriver.latest_version).to eq Gem::Version.new('115.0.5790.102')
+      expect(Webdrivers::Network).to have_received(:get).with(uri)
+    end
   end
 
   describe '#required_version=' do


### PR DESCRIPTION
similar Issue: https://github.com/titusfortner/webdrivers/issues/247

f the version is 115 or higher, the API can be used, so if the version is 115 or higher, the stable version is obtained and downloaded from the API.

refarence
- https://chromedriver.chromium.org/downloads
- https://github.com/GoogleChromeLabs/chrome-for-testing#json-api-endpoints