### PR TITLE
update selenium-webdriver to account for latest version

### DIFF
--- a/webdrivers.gemspec
+++ b/webdrivers.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'nokogiri', '~> 1.6'
   s.add_runtime_dependency 'rubyzip', '>= 1.3.0'
-  s.add_runtime_dependency 'selenium-webdriver', '~> 4.0', '< 4.11'
+  s.add_runtime_dependency 'selenium-webdriver', '~> 4.0', '<= 4.11'
 
   s.post_install_message = <<~ENDBANNER
     Webdrivers gem update options


### PR DESCRIPTION
The gem `selenium-webdriver` has been updated:
https://github.com/SeleniumHQ/selenium/blob/trunk/rb/CHANGES#L1

To ensure we can update this gem in or project we need to update `webdrivers.gemspec` to ensure we can get the latest version.

Resolves issue: https://github.com/titusfortner/webdrivers/issues/257